### PR TITLE
Require glue 1.5.0 and enable `<el>#<id>` in `epoxyHTML()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ License: MIT + file LICENSE
 URL: https://github.com/gadenbuie/epoxy
 BugReports: https://github.com/gadenbuie/epoxy/issues
 Imports:
-    glue,
+    glue (>= 1.5.0),
     htmltools,
     knitr,
     purrr,
@@ -18,6 +18,7 @@ Imports:
     rmarkdown,
     shiny,
     stringr,
+    utils,
     whisker
 Suggests:
     testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@
   knitr engine with similar functionality. epoxy also provides `epoxy_html` and
   `epoxy_latex` knitr engines, although they can still be used via their aliases
   `glue_html` and `glue_latex`. (#21)
+  
+* `epoxyHTML()` will now render elements with IDs using the `#` syntax, e.g.
+  `{{h3#name.author full_name}}` will create an element that is (essentially)
+  `<h3 id="name" class="author">{{ full_name }}</h3>` (#22).
+
+* epoxy requires glue >= 1.5.0.
 
 # epoxy 0.0.2
 

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -166,7 +166,6 @@ transformer_js_literal <- function(text, envir) {
 
 transformer_html_markup <- function(class = NULL, element = "span") {
   class <- collapse_space(c("epoxy-item__placeholder", class))
-  default_placeholder <- get(".placeholder", envir = envir, inherits = FALSE)
 
   function(text, envir) {
     markup <- parse_html_markup(text)
@@ -174,7 +173,7 @@ transformer_html_markup <- function(class = NULL, element = "span") {
       markup$item,
       env = envir,
       inherit = TRUE,
-      default = default_placeholder
+      default = get(".placeholder", envir = envir, inherits = FALSE)
     )
     tag_name <- markup$element
     if (is.null(tag_name)) tag_name <- element

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -13,11 +13,10 @@
 #' placeholder inside an `<h3 id="basic-three" class="example basic"></h3>` tag.
 #'
 #' The placeholder template string follows the pattern `{{<markup> <name>}}`.
-#' The markup syntax comes first, separated from the placeholder name by a space.
-#' The HTML element is first, followed by classes prefixed with `.` or and ID
-#' prefixed with `%`. Note that due to the way that [glue::glue()] parses the
-#' template string, an `%` is needed instead of `#`. The template markup can
-#' contain only one element and one ID, but many classes can be specified.
+#' The markup syntax comes first, separated from the placeholder name by a
+#' space. The HTML element is first, followed by classes prefixed with `.` or
+#' and ID prefixed with `#`. The template markup can contain only one element
+#' and one ID, but many classes can be specified.
 #'
 #' @examples
 #' \dontrun{
@@ -127,6 +126,11 @@ epoxyHTML <- function(
   dots$.close = .close %||% "}}"
   dots$.envir = new.env(parent = emptyenv())
 
+  if (utils::packageVersion("glue") >= "1.5.0") {
+    # {glue} 1.5.0 added .comment arg that we use to disable # as comment
+    dots$.comment <- character()
+  }
+
   tags <- purrr::keep(dots, is_tag)
   deps <- if (length(tags)) {
     purrr::flatten(purrr::map(tags, htmltools::findDependencies))
@@ -162,11 +166,15 @@ transformer_js_literal <- function(text, envir) {
 
 transformer_html_markup <- function(class = NULL, element = "span") {
   class <- collapse_space(c("epoxy-item__placeholder", class))
+  default_placeholder <- get(".placeholder", envir = envir, inherits = FALSE)
+
   function(text, envir) {
     markup <- parse_html_markup(text)
-    placeholder <- tryCatch(
-      rlang::env_get(markup$item, env = envir, inherit = TRUE),
-      error = function(...) get(".placeholder", envir = envir, inherits = FALSE)
+    placeholder <- rlang::env_get(
+      markup$item,
+      env = envir,
+      inherit = TRUE,
+      default = default_placeholder
     )
     tag_name <- markup$element
     if (is.null(tag_name)) tag_name <- element

--- a/man/epoxyHTML.Rd
+++ b/man/epoxyHTML.Rd
@@ -70,11 +70,10 @@ markup syntax, \code{"{{h3.example.basic\%basic-three demo}}"} creates a \code{d
 placeholder inside an \verb{<h3 id="basic-three" class="example basic"></h3>} tag.
 
 The placeholder template string follows the pattern \verb{\{\{<markup> <name>\}\}}.
-The markup syntax comes first, separated from the placeholder name by a space.
-The HTML element is first, followed by classes prefixed with \code{.} or and ID
-prefixed with \verb{\%}. Note that due to the way that \code{\link[glue:glue]{glue::glue()}} parses the
-template string, an \verb{\%} is needed instead of \verb{#}. The template markup can
-contain only one element and one ID, but many classes can be specified.
+The markup syntax comes first, separated from the placeholder name by a
+space. The HTML element is first, followed by classes prefixed with \code{.} or
+and ID prefixed with \verb{#}. The template markup can contain only one element
+and one ID, but many classes can be specified.
 }
 
 \examples{


### PR DESCRIPTION
`epoxyHTML()` will now render `#id` syntax for inline elements, e.g. `{{h3#name full_name}}`:

```r
epoxyHTML("demo", "{{h3#name full_name}}")
#> <div id="demo" class="epoxy-html epoxy-init">
#>   <h3 class="epoxy-item__placeholder" id="name" data-epoxy-item="full_name"></h3>
#> </div>
```

Requires glue 1.5.0

Fixes #19 