### PR TITLE
`epoxy_style()` chooses syntax by engine

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,11 @@
   
 * Added a new `vignette("inline-reporting")` with thanks to @tjmahr for the
   [inspiration](https://www.tjmahr.com/lists-knitr-secret-weapon/) (#25).
+  
+* The epoxy style transformers for bold, italic and code styles now choose the
+  correct syntax for the `epoxy` (markdown), `epoxy_html` and `epoxy_latex`
+  engines. Alternatively, you can force the desired syntax by setting the
+  `syntax` option (#28).
 
 # epoxy 0.0.2
 

--- a/R/transformers.R
+++ b/R/transformers.R
@@ -101,9 +101,20 @@ close_over_transformer <- function(expr, env) {
 #' @param before,after In `epoxy_style_wrap()`, the characters to be added
 #'   before and after variables in the template string.
 #' @export
-epoxy_style_wrap <- function(before = "**", after = before, transformer = glue::identity_transformer) {
+epoxy_style_wrap <- function(
+  before = "**",
+  after = before,
+  syntax = NULL,
+  transformer = glue::identity_transformer
+) {
   if (!is.null(getOption("epoxy.engine", NULL))) {
     force(list(before, after))
+  }
+  if (!is.null(syntax)) {
+    with_options(
+      list(epoxy.engine = syntax),
+      list(before, after)
+    )
   }
   function(text, envir) {
     paste0(before, transformer(text, envir), after)
@@ -113,10 +124,11 @@ epoxy_style_wrap <- function(before = "**", after = before, transformer = glue::
 #' @describeIn epoxy_style Embolden variables using `**` in markdown, `<strong>`
 #'   in HTML, or `\textbf{}` in LaTeX
 #' @export
-epoxy_style_bold <- function(transformer = glue::identity_transformer) {
+epoxy_style_bold <- function(syntax = NULL, transformer = glue::identity_transformer) {
   epoxy_style_wrap(
     before = default_for_engine("**", "<strong>", "\\textbf{"),
     after = default_for_engine("**", "</strong>", "}"),
+    syntax = syntax,
     transformer = transformer
   )
 }
@@ -124,10 +136,11 @@ epoxy_style_bold <- function(transformer = glue::identity_transformer) {
 #' @describeIn epoxy_style Italicize variables using `_` in markdown, `<em>` in
 #'   HTML, or `\emph{}` in LaTeX
 #' @export
-epoxy_style_italic <- function(transformer = glue::identity_transformer) {
+epoxy_style_italic <- function(syntax = NULL, transformer = glue::identity_transformer) {
   epoxy_style_wrap(
     before = default_for_engine("_", "<em>", "\\emph{"),
     after = default_for_engine("_", "</em>", "}"),
+    syntax = syntax,
     transformer = transformer
   )
 }
@@ -135,10 +148,11 @@ epoxy_style_italic <- function(transformer = glue::identity_transformer) {
 #' @describeIn epoxy_style Code format variables using ` `` ` in markdown,
 #'   `<code>` in HTML, or `\texttt{}` in LaTeX
 #' @export
-epoxy_style_code <- function(transformer = glue::identity_transformer) {
+epoxy_style_code <- function(syntax = NULL, transformer = glue::identity_transformer) {
   epoxy_style_wrap(
     before = default_for_engine("`", "<code>", "\\texttt{"),
     after = default_for_engine("`", "</code>", "}"),
+    syntax = syntax,
     transformer = transformer
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,3 +36,9 @@ collapse_space <- function(...) {
 }
 
 is_tag <- function(x) inherits(x, "shiny.tag")
+
+with_options <- function(opts, expr) {
+  old <- options(opts)
+  on.exit(options(old))
+  force(expr)
+}

--- a/man/epoxy_style.Rd
+++ b/man/epoxy_style.Rd
@@ -14,14 +14,15 @@ epoxy_style(..., syntax = NULL)
 epoxy_style_wrap(
   before = "**",
   after = before,
+  syntax = NULL,
   transformer = glue::identity_transformer
 )
 
-epoxy_style_bold(transformer = glue::identity_transformer)
+epoxy_style_bold(syntax = NULL, transformer = glue::identity_transformer)
 
-epoxy_style_italic(transformer = glue::identity_transformer)
+epoxy_style_italic(syntax = NULL, transformer = glue::identity_transformer)
 
-epoxy_style_code(transformer = glue::identity_transformer)
+epoxy_style_code(syntax = NULL, transformer = glue::identity_transformer)
 
 epoxy_style_collapse(
   sep = ", ",

--- a/man/epoxy_style.Rd
+++ b/man/epoxy_style.Rd
@@ -13,7 +13,7 @@ epoxy_style(...)
 
 epoxy_style_wrap(
   before = "**",
-  after = "**",
+  after = before,
   transformer = glue::identity_transformer
 )
 
@@ -69,23 +69,55 @@ argument of \code{\link[glue:glue]{glue::glue()}}.
 These transformers provide additional automatic formatting for the template
 strings. They are designed to be used with the \code{.transformer} chunk option of
 in \code{epoxy} chunks. You can use \code{epoxy_style()} to chain several transformers
-together.
+together. \code{epoxy_style()} and individual \pkg{epoxy} style functions can be
+used in \code{epoxy}, \code{epoxy_html} and \code{epoxy_latex} chunks and will choose the
+correct syntax for each.
 }
 \section{Functions}{
 \itemize{
 \item \code{epoxy_style_wrap}: Wrap variables
 
-\item \code{epoxy_style_bold}: Embolden variables using markdown \verb{**} syntax
+\item \code{epoxy_style_bold}: Embolden variables using \verb{**} in markdown, \verb{<strong>}
+in HTML, or \verb{\\textbf\{\}} in LaTeX
 
-\item \code{epoxy_style_italic}: Italicize variables using markdown \verb{_} syntax
+\item \code{epoxy_style_italic}: Italicize variables using \verb{_} in markdown, \verb{<em>} in
+HTML, or \verb{\\emph\{\}} in LaTeX
 
-\item \code{epoxy_style_code}: Code format variables using markdown backtick syntax
+\item \code{epoxy_style_code}: Code format variables using \verb{``} in markdown,
+\verb{<code>} in HTML, or \verb{\\texttt\{\}} in LaTeX
 
-\item \code{epoxy_style_collapse}: Collapse vector variables.
+\item \code{epoxy_style_collapse}: Collapse vector variables
 }}
+
+\section{Output-specific styling}{
+
+The \code{epoxy_style_} functions will attempt to use the correct syntax for
+styling the replacement text for markdown, HTML and LaTeX. This choice is
+driven by the chunk engine where the styling function is used. The \code{epoxy}
+engine corresponds to markdown, \code{epoxy_html} to HTML, and \code{epoxy_latex} to
+LaTeX.
+
+The engine detection only works when the epoxy style functions are used
+with epoxy knitr engines and during the knitr rendering process. When
+used outside of this context, you can choose the desired syntax by setting
+the \code{epoxy.engine} option, e.g. \code{options(epoxy.engine = "epoxy_html")} for
+the \code{epoxy_html} engine.
+}
 
 \examples{
 glue::glue("{letters[1:3]&}", .transformer = epoxy_style("bold", "collapse"))
 glue::glue("{letters[1:3]&}", .transformer = epoxy_style("collapse", "bold"))
+
+old <- options(epoxy.engine = "epoxy_html")
+# In an epoxy_html chunk...
+# (you don't need to set that option, it's only needed for these examples)
+glue::glue("{letters[1:3]&}", .transformer = epoxy_style("bold", "collapse"))
+
+options(epoxy.engine = "epoxy_latex")
+# Or in an epoxy_latex chunk...
+glue::glue("{letters[1:3]&}", .transformer = epoxy_style("bold", "collapse"))
+
+# restore (or more likely unset) your original options
+options(old)
 
 }

--- a/man/epoxy_style.Rd
+++ b/man/epoxy_style.Rd
@@ -9,7 +9,7 @@
 \alias{epoxy_style_collapse}
 \title{epoxy Style Transformers}
 \usage{
-epoxy_style(...)
+epoxy_style(..., syntax = NULL)
 
 epoxy_style_wrap(
   before = "**",
@@ -43,6 +43,11 @@ For example, \code{epoxy_style("bold", "collapse")} results in replaced strings
 that are emboldened \emph{and then} collapsed, e.g. \verb{**a** and **b**}. On the
 other hand, \code{epoxy_style("collapse", "bold")}  will collapse the vector
 \emph{and then} embolden the entire string.}
+
+\item{syntax}{One of \code{"markdown"} (or \code{"md"}), \code{"html"}, or \code{"latex"}. The
+default is chosen based on the engine of the chunk where the style function
+is called, or according to the option \code{epoxy.engine}. Caution: invalid
+options are silently ignored, falling back to markdown syntax.}
 
 \item{before, after}{In \code{epoxy_style_wrap()}, the characters to be added
 before and after variables in the template string.}
@@ -97,27 +102,27 @@ driven by the chunk engine where the styling function is used. The \code{epoxy}
 engine corresponds to markdown, \code{epoxy_html} to HTML, and \code{epoxy_latex} to
 LaTeX.
 
-The engine detection only works when the epoxy style functions are used
+Automatic syntax selection only works when the epoxy style functions are used
 with epoxy knitr engines and during the knitr rendering process. When
 used outside of this context, you can choose the desired syntax by setting
-the \code{epoxy.engine} option, e.g. \code{options(epoxy.engine = "epoxy_html")} for
-the \code{epoxy_html} engine.
+the \code{syntax} to one of \code{"markdown"}, \code{"html"} or \code{"latex"}.
 }
 
 \examples{
 glue::glue("{letters[1:3]&}", .transformer = epoxy_style("bold", "collapse"))
 glue::glue("{letters[1:3]&}", .transformer = epoxy_style("collapse", "bold"))
 
-old <- options(epoxy.engine = "epoxy_html")
 # In an epoxy_html chunk...
-# (you don't need to set that option, it's only needed for these examples)
-glue::glue("{letters[1:3]&}", .transformer = epoxy_style("bold", "collapse"))
+# Note that you don't have to set `syntax = "html"`, it just knows
+glue::glue(
+  "{letters[1:3]&}",
+  .transformer = epoxy_style("bold", "collapse", syntax = "html")
+)
 
-options(epoxy.engine = "epoxy_latex")
 # Or in an epoxy_latex chunk...
-glue::glue("{letters[1:3]&}", .transformer = epoxy_style("bold", "collapse"))
-
-# restore (or more likely unset) your original options
-options(old)
+glue::glue(
+  "{letters[1:3]&}",
+  .transformer = epoxy_style("bold", "collapse", syntax = "latex")
+)
 
 }

--- a/tests/testthat/test-transformers.R
+++ b/tests/testthat/test-transformers.R
@@ -68,3 +68,38 @@ test_that("epoxy_style() throws an error for unknown styles", {
     "doesn't exist"
   )
 })
+
+test_that("epoxy_style_*() functions choose default by engine", {
+  with_options(
+    list(epoxy.engine = "epoxy"),
+    expect_equal(
+      glue("{'word'}", .transformer = epoxy_style("bold")),
+      "**word**"
+    )
+  )
+
+  with_options(
+    list(epoxy.engine = "epoxy_html"),
+    expect_equal(
+      glue("{'word'}", .transformer = epoxy_style("bold")),
+      "<strong>word</strong>"
+    )
+  )
+
+  with_options(
+    list(epoxy.engine = "epoxy_latex"),
+    expect_equal(
+      glue("{'word'}", .transformer = epoxy_style("bold")),
+      "\\textbf{word}"
+    )
+  )
+
+  # markdown by default
+  with_options(
+    list(epoxy.engine = "foo"),
+    expect_equal(
+      glue("{'word'}", .transformer = epoxy_style("bold")),
+      "**word**"
+    )
+  )
+})

--- a/tests/testthat/test-transformers.R
+++ b/tests/testthat/test-transformers.R
@@ -69,7 +69,7 @@ test_that("epoxy_style() throws an error for unknown styles", {
   )
 })
 
-test_that("epoxy_style_*() functions choose default by engine", {
+test_that("epoxy_style_*() chooses syntax by epoxy.engine option", {
   with_options(
     list(epoxy.engine = "epoxy"),
     expect_equal(
@@ -101,5 +101,42 @@ test_that("epoxy_style_*() functions choose default by engine", {
       glue("{'word'}", .transformer = epoxy_style("bold")),
       "**word**"
     )
+  )
+})
+
+test_that("epoxy_style_*() functions choose syntax by argument", {
+  expect_equal(
+    glue("{'text'}", .transformer = epoxy_style_bold(syntax = "md")),
+    "**text**"
+  )
+
+  expect_equal(
+    glue("{'text'}", .transformer = epoxy_style_bold(syntax = "markdown")),
+    "**text**"
+  )
+
+  expect_equal(
+    glue("{'text'}", .transformer = epoxy_style("bold", syntax = "markdown")),
+    "**text**"
+  )
+
+  expect_equal(
+    glue("{'text'}", .transformer = epoxy_style_bold(syntax = "html")),
+    "<strong>text</strong>"
+  )
+
+  expect_equal(
+    glue("{'text'}", .transformer = epoxy_style("bold", syntax = "html")),
+    "<strong>text</strong>"
+  )
+
+  expect_equal(
+    glue("{'text'}", .transformer = epoxy_style_bold(syntax = "latex")),
+    "\\textbf{text}"
+  )
+
+  expect_equal(
+    glue("{'text'}", .transformer = epoxy_style("bold", syntax = "latex")),
+    "\\textbf{text}"
   )
 })


### PR DESCRIPTION
`epoxy_style()` is now aware of the engine where it is being used and will attempt to use the appropriate syntax for the engine. Alternatively you can set the `syntax` argument in `epoxy_style()` to one of `"markdown"`, `"html"`, or `"latex"`, or you could set the `epoxy.engine` option to one of those option or the name of the epoxy engine.

In an `epoxy` chunk:

``` r
glue::glue("{letters[1:3]&}", .transformer = epoxy_style("bold", "collapse"))
#> **a**, **b** and **c**
```

In an `epoxy_html` chunk...

```r
# Note that you don't have to set `syntax = "html"`, it just knows
glue::glue(
  "{letters[1:3]&}",
  .transformer = epoxy_style("bold", "collapse", syntax = "html")
)
#> <strong>a</strong>, <strong>b</strong> and <strong>c</strong>
```

Or in an `epoxy_latex` chunk...

```r
glue::glue(
  "{letters[1:3]&}",
  .transformer = epoxy_style("bold", "collapse", syntax = "latex")
)
#> \textbf{a}, \textbf{b} and \textbf{c}
```

Closes #27 