### PR TITLE
Add `epoxy_style` chunk option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
   to use both `epoxy_style_bold()` and `epoxy_style_collapse()` on all
   replacement strings, you can call `epoxy_style("bold", "collapse")`.
   `epoxy_style()` accepts a style function name, e.g. `"collapse"`, the function
-  objet directly, e.g. `epoxy_style_collapse`, or a call to a style function,
+  object directly, e.g. `epoxy_style_collapse`, or a call to a style function,
   e.g. `epoxy_style_collapse()` (#26).
   
 * Added a new `vignette("inline-reporting")` with thanks to @tjmahr for the
@@ -37,6 +37,11 @@
   can instead simply `library(epoxy)`. epoxy previously provided a `glue` chunk
   rather than an `epoxy` chunk and you can restore this behavior by calling
   `use_epoxy_glue_engine()` (#30).
+
+* Added a new chunk option, `epoxy_style`, that takes precedence over the
+  `.transformer` chunk option. The new chunk option is best paired with 
+  `epoxy_style()`, and for convenience you can prove a vector of style names or
+  a list of functions, e.g. `epoxy_style = c("bold", "collapse")` (#31).
 
 # epoxy 0.0.2
 

--- a/R/engines.R
+++ b/R/engines.R
@@ -75,7 +75,7 @@ knitr_engine_epoxy <- function(options) {
       .close = options[[".close"]] %||% "}",
       .na = options[[".na"]] %||% "",
       .trim = options[[".trim"]] %||% FALSE,
-      .transformer = options[[".transformer"]] %||% glue::identity_transformer
+      .transformer = epoxy_options_get_transformer(options)
     )
   }
   options$results <- "asis"
@@ -101,7 +101,7 @@ knitr_engine_epoxy_html <- function(options) {
       .close = options[[".close"]] %||% "}}",
       .na = options[[".na"]] %||% "",
       .trim = options[[".trim"]] %||% FALSE,
-      .transformer = options[[".transformer"]] %||% glue::identity_transformer
+      .transformer = epoxy_options_get_transformer(options)
     )
     code <- glue_collapse(code, sep = "\n")
     if (isTRUE(options$html_raw %||% TRUE)) {
@@ -134,7 +134,7 @@ knitr_engine_epoxy_latex <- function(options) {
       .close = options[[".close"]] %||% ">",
       .na = options[[".na"]] %||% "",
       .trim = options[[".trim"]] %||% FALSE,
-      .transformer = options[[".transformer"]] %||% glue::identity_transformer
+      .transformer = epoxy_options_get_transformer(options)
     )
   }
   options$results <- "asis"
@@ -197,6 +197,14 @@ epoxy_data_subset <- function(x, y) {
   x <- lapply(x, function(.x) base::`[[`(.x, y))
   x_len_1 <- vapply(x, function(x) length(x) == 1, logical(1))
   if (all(x_len_1)) unlist(x) else x
+}
+
+epoxy_options_get_transformer <- function(options) {
+  style <- options[["epoxy_style"]]
+  if (is.vector(style) || is.list(style)) {
+    return(epoxy_style(!!!style))
+  }
+  style %||% options[[".transformer"]] %||% glue::identity_transformer
 }
 
 deprecate_glue_data_chunk_option <- function(options) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -86,20 +86,20 @@ RStudio autocompletion works inside `epoxy` chunks!
 
 ### Style replaced values
 
-You can use the `epoxy_style_wrap()` with the `.transformer` chunk option
-to wrap the evaluated R expression in formating or templating text.
+You can use the `epoxy_style_wrap()` with the `epoxy_style` chunk option
+to wrap the evaluated R expression in formatting or templating text.
 Or you can use the pre-set
 `epoxy_style_bold()`, `epoxy_style_italic()`, or `epoxy_style_code()`
-style transformers.
+style transformers or with `epoxy_style()`.
 
 ````
-```{epoxy, .transformer = epoxy_style_bold()}`r ''`
+```{epoxy, epoxy_style = epoxy_style("bold")}`r ''`
 All cars stopped between {min(cars$dist)} and {max(cars$dist)} feet
 from a starting speed of {min(cars$speed)}---{max(cars$speed)}
 ```
 ````
 
-```{epoxy, .transformer = epoxy_style_bold()}
+```{epoxy, epoxy_style = epoxy_style("bold")}
 All cars stopped between {min(cars$dist)} and {max(cars$dist)} feet
 from a starting speed of {min(cars$speed)}---{max(cars$dist)} mph.
 ```
@@ -128,14 +128,14 @@ to the end of the expression.
 - `|` collapses with commas and adds `" or "` between the last two items.
 
 ````
-```{epoxy, .transformer = epoxy_style_collapse()}`r ''`
+```{epoxy, epoxy_style = epoxy_style("collapse")}`r ''`
 - The first three letters are {letters[1:3]*}.
 - When capitalized, they are {LETTERS[1:3]&}.
 - They're indexed by {1:3|}.
 ```
 ````
 
-```{epoxy, .transformer = epoxy_style_collapse()}
+```{epoxy, epoxy_style = epoxy_style("collapse"))}
 - The first three letters are {letters[1:3]*}.
 - When capitalized, they are {LETTERS[1:3]&}.
 - They're indexed by {1:3|}.

--- a/README.Rmd
+++ b/README.Rmd
@@ -135,7 +135,7 @@ to the end of the expression.
 ```
 ````
 
-```{epoxy, epoxy_style = epoxy_style("collapse"))}
+```{epoxy, epoxy_style = epoxy_style("collapse")}
 - The first three letters are {letters[1:3]*}.
 - When capitalized, they are {LETTERS[1:3]&}.
 - They're indexed by {1:3|}.

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ With an amazing stroke of luck, RStudio autocompletion works inside
 
 ### Style replaced values
 
-You can use the `epoxy_style_wrap()` with the `.transformer` chunk
-option to wrap the evaluated R expression in formating or templating
-text. Or you can use the pre-set `epoxy_style_bold()`,
-`epoxy_style_italic()`, or `epoxy_style_code()` style transformers.
+You can use the `epoxy_style_wrap()` with the `epoxy_style` chunk option
+to wrap the evaluated R expression in formatting or templating text. Or
+you can use the pre-set `epoxy_style_bold()`, `epoxy_style_italic()`, or
+`epoxy_style_code()` style transformers or with `epoxy_style()`.
 
-    ```{epoxy, .transformer = epoxy_style_bold()}
+    ```{epoxy, epoxy_style = epoxy_style("bold")}
     All cars stopped between {min(cars$dist)} and {max(cars$dist)} feet
     from a starting speed of {min(cars$speed)}---{max(cars$speed)}
     ```
@@ -112,7 +112,7 @@ transformer. You can then choose how vectors are collapsed by adding
 
 <!-- end list -->
 
-    ```{epoxy, .transformer = epoxy_style_collapse()}
+    ```{epoxy, epoxy_style = epoxy_style("collapse")}
     - The first three letters are {letters[1:3]*}.
     - When capitalized, they are {LETTERS[1:3]&}.
     - They're indexed by {1:3|}.


### PR DESCRIPTION
Adds `epoxy_style` chunk option that takes precedence over `.transformer`. This chunk option also allows a vector or list of style names, e.g. `epoxy_style = c("code", "bold")` or `epoxy_style = list(epoxy_style_bold)`.

I like this chunk option name better than `.transformer`, which is too technical, but this also makes epoxy work better with Quarto. (There's something happening where using chunk options that start with `.` causes unexpected output.)