### PR TITLE
Add return value and fill in examples for shiny functions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^\.github$
 ^_pkgdown\.yml$
 ^data-raw$
+^pkgdown$

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -19,33 +19,31 @@
 #' and one ID, but many classes can be specified.
 #'
 #' @examples
-#' \dontrun{
-#' library(shiny)
-#'
-#' ui <- fluidPage(
-#'   h2("epoxyHTML demo"),
-#'   epoxy:::epoxyHTML(
-#'     'test',
-#'     fluidRow(
-#'       tags$div(
+#' ui <- shiny::fluidPage(
+#'   shiny::h2("epoxyHTML demo"),
+#'   epoxyHTML(
+#'     .id = 'test',
+#'     .class_item = "inner",
+#'     shiny::fluidRow(
+#'       shiny::tags$div(
 #'         class = "col-xs-4",
-#'         selectInput(
+#'         shiny::selectInput(
 #'           inputId = "thing",
 #'           label = "What is this {{color}} thing?",
 #'           choices = c("apple", "banana", "coconut", "dolphin")
 #'         )
 #'       ),
-#'       tags$div(
+#'       shiny::tags$div(
 #'         class = "col-xs-4",
-#'         selectInput(
+#'         shiny::selectInput(
 #'           inputId = "color",
 #'           label = "What color is the {{thing}}?",
 #'           c("red", "blue", "black", "green", "yellow")
 #'         )
 #'       ),
-#'       tags$div(
+#'       shiny::tags$div(
 #'         class = "col-xs-4",
-#'         sliderInput(
+#'         shiny::sliderInput(
 #'           inputId = "height",
 #'           label = "How tall is the {{color}} {{thing}}?",
 #'           value = 5,
@@ -56,13 +54,13 @@
 #'         )
 #'       )
 #'     ),
-#'     tags$p(class = "big", "The {{color}} {{thing}} is {{height}} feet tall."),
+#'     shiny::tags$p(class = "big", "The {{color}} {{thing}} is {{height}} feet tall."),
+#'     # Default values for placeholders above.
 #'     thing = "THING",
 #'     color = "COLOR",
-#'     height = "HEIGHT",
-#'     .class_item = "inner"
+#'     height = "HEIGHT"
 #'   ),
-#'   tags$style(HTML(
+#'   shiny::tags$style(shiny::HTML(
 #'     '.big { font-size: 1.5em; }
 #'     .inner:not(.epoxy-item__placeholder) { background-color: rgba(254, 233, 105, 0.5)}
 #'     .epoxy-item__placeholder { color: #999999; }'
@@ -70,14 +68,15 @@
 #' )
 #'
 #' server <- function(input, output, session) {
-#'   output$test <- epoxy:::renderEpoxyHTML(
+#'   output$test <- renderEpoxyHTML(
 #'     thing = input$thing,
 #'     color = input$color,
 #'     height = input$height
 #'   )
 #' }
 #'
-#' shinyApp(ui, server)
+#' if (interactive()) {
+#'   shiny::shinyApp(ui, server)
 #' }
 #'
 #' @param .id The output id

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -236,7 +236,34 @@ parse_html_markup <- function(x) {
 #'
 #' Server-side render function used to provide values for template items. Use
 #' named values matching the template variable names in the associated
-#' `epoxyHTML()`.
+#' `epoxyHTML()`. When the values are updated by the app, `renderEpoxyHTML()`
+#' will update the values shown in the app's UI.
+#'
+#' @examples
+#' # This small app shows the current time using `epoxyHTML()`
+#' # to provide the HTML template and `renderEpoxyHTML()` to
+#' # update the current time every second.
+#'
+#' ui <- shiny::fluidPage(
+#'   shiny::h2("Current Time"),
+#'   epoxyHTML(
+#'     "time",
+#'     shiny::p("The current time is {{strong time}}.")
+#'   )
+#' )
+#'
+#' server <- function(input, output, session) {
+#'   current_time <- shiny::reactive({
+#'     shiny::invalidateLater(1000)
+#'     strftime(Sys.time(), "%F %T")
+#'   })
+#'
+#'   output$time <- renderEpoxyHTML(time = current_time())
+#' }
+#'
+#' if (interactive()) {
+#'   shiny::shinyApp(ui, server)
+#' }
 #'
 #' @param ... Named values corresponding to the template variables created with
 #'   the associated [epoxyHTML()] UI element.
@@ -248,7 +275,11 @@ parse_html_markup <- function(x) {
 #'   call to [epoxyHTML()] when `renderEpoxyHTML` is used in an interactive R
 #'   Markdown document.
 #'
-#' @seealso epoxyHTML
+#' @return A server-side Shiny render function that should be assigned to
+#'   Shiny's `output` object and named to match the `.id` of the corresponding
+#'   [epoxyHTML()] call.
+#'
+#' @seealso [epoxyHTML()]
 #' @export
 renderEpoxyHTML <- function(..., .list = NULL, env = parent.frame(), outputArgs = list()) {
   epoxyPrepare <- function(..., .list = NULL) {

--- a/man/epoxyHTML.Rd
+++ b/man/epoxyHTML.Rd
@@ -77,33 +77,31 @@ and one ID, but many classes can be specified.
 }
 
 \examples{
-\dontrun{
-library(shiny)
-
-ui <- fluidPage(
-  h2("epoxyHTML demo"),
-  epoxy:::epoxyHTML(
-    'test',
-    fluidRow(
-      tags$div(
+ui <- shiny::fluidPage(
+  shiny::h2("epoxyHTML demo"),
+  epoxyHTML(
+    .id = 'test',
+    .class_item = "inner",
+    shiny::fluidRow(
+      shiny::tags$div(
         class = "col-xs-4",
-        selectInput(
+        shiny::selectInput(
           inputId = "thing",
           label = "What is this {{color}} thing?",
           choices = c("apple", "banana", "coconut", "dolphin")
         )
       ),
-      tags$div(
+      shiny::tags$div(
         class = "col-xs-4",
-        selectInput(
+        shiny::selectInput(
           inputId = "color",
           label = "What color is the {{thing}}?",
           c("red", "blue", "black", "green", "yellow")
         )
       ),
-      tags$div(
+      shiny::tags$div(
         class = "col-xs-4",
-        sliderInput(
+        shiny::sliderInput(
           inputId = "height",
           label = "How tall is the {{color}} {{thing}}?",
           value = 5,
@@ -114,13 +112,13 @@ ui <- fluidPage(
         )
       )
     ),
-    tags$p(class = "big", "The {{color}} {{thing}} is {{height}} feet tall."),
+    shiny::tags$p(class = "big", "The {{color}} {{thing}} is {{height}} feet tall."),
+    # Default values for placeholders above.
     thing = "THING",
     color = "COLOR",
-    height = "HEIGHT",
-    .class_item = "inner"
+    height = "HEIGHT"
   ),
-  tags$style(HTML(
+  shiny::tags$style(shiny::HTML(
     '.big { font-size: 1.5em; }
     .inner:not(.epoxy-item__placeholder) { background-color: rgba(254, 233, 105, 0.5)}
     .epoxy-item__placeholder { color: #999999; }'
@@ -128,14 +126,15 @@ ui <- fluidPage(
 )
 
 server <- function(input, output, session) {
-  output$test <- epoxy:::renderEpoxyHTML(
+  output$test <- renderEpoxyHTML(
     thing = input$thing,
     color = input$color,
     height = input$height
   )
 }
 
-shinyApp(ui, server)
+if (interactive()) {
+  shiny::shinyApp(ui, server)
 }
 
 }

--- a/man/renderEpoxyHTML.Rd
+++ b/man/renderEpoxyHTML.Rd
@@ -20,11 +20,44 @@ corresponding to the template variables created with the associated
 call to \code{\link[=epoxyHTML]{epoxyHTML()}} when \code{renderEpoxyHTML} is used in an interactive R
 Markdown document.}
 }
+\value{
+A server-side Shiny render function that should be assigned to
+Shiny's \code{output} object and named to match the \code{.id} of the corresponding
+\code{\link[=epoxyHTML]{epoxyHTML()}} call.
+}
 \description{
 Server-side render function used to provide values for template items. Use
 named values matching the template variable names in the associated
-\code{epoxyHTML()}.
+\code{epoxyHTML()}. When the values are updated by the app, \code{renderEpoxyHTML()}
+will update the values shown in the app's UI.
+}
+\examples{
+# This small app shows the current time using `epoxyHTML()`
+# to provide the HTML template and `renderEpoxyHTML()` to
+# update the current time every second.
+
+ui <- shiny::fluidPage(
+  shiny::h2("Current Time"),
+  epoxyHTML(
+    "time",
+    shiny::p("The current time is {{strong time}}.")
+  )
+)
+
+server <- function(input, output, session) {
+  current_time <- shiny::reactive({
+    shiny::invalidateLater(1000)
+    strftime(Sys.time(), "\%F \%T")
+  })
+
+  output$time <- renderEpoxyHTML(time = current_time())
+}
+
+if (interactive()) {
+  shiny::shinyApp(ui, server)
+}
+
 }
 \seealso{
-epoxyHTML
+\code{\link[=epoxyHTML]{epoxyHTML()}}
 }


### PR DESCRIPTION
adds return value and example for `renderEpoxyHTML()`, tweaks the example in`epoxyHTML()`