### PR TITLE
Make `epoxy_style_format()` the default transformer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,10 @@
   labellers. For example, `{fmt(x, "%")}` will format `x` as a percentage using
   `scales::label_percent()` and `{fmt(x, "$")}` will format `x` as a dollar
   figure. You can also provide your own functions (#39).
+  
+* `epoxy_style_format()` is now the default transformer for all epoxy chunks,
+  making the inline `fmt()` function available in `epoxy`, `epoxy_html` and
+  `epoxy_latex` chunks (#44).
 
 # epoxy 0.0.2
 

--- a/R/engines.R
+++ b/R/engines.R
@@ -204,7 +204,7 @@ epoxy_options_get_transformer <- function(options) {
   if (is.vector(style) || is.list(style)) {
     return(epoxy_style(!!!style))
   }
-  style %||% options[[".transformer"]] %||% glue::identity_transformer
+  style %||% options[[".transformer"]] %||% epoxy_style_format()
 }
 
 deprecate_glue_data_chunk_option <- function(options) {


### PR DESCRIPTION
Makes `epoxy_style_format()` the default transformer
Closes #42 