### PR TITLE
Use {and} for `epoxy_style_collapse()` and add collapse to default transformer

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -44,6 +44,8 @@ jobs:
           extra-packages: rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v2
+        env:
+          LANGUAGE: en
 
       - name: Update gadenbuie/status dashboard
         uses: gadenbuie/status/actions/status-update-rcmdcheck@main

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -44,8 +44,6 @@ jobs:
           extra-packages: rcmdcheck
 
       - uses: r-lib/actions/check-r-package@v2
-        env:
-          LANGUAGE: en
 
       - name: Update gadenbuie/status dashboard
         uses: gadenbuie/status/actions/status-update-rcmdcheck@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ BugReports: https://github.com/gadenbuie/epoxy/issues
 Depends: 
     R (>= 2.10)
 Imports:
+    and (>= 0.0.0.9007),
     glue (>= 1.5.0),
     htmltools,
     knitr (>= 1.37),
@@ -36,3 +37,5 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.0
+Remotes:  
+    rossellhayes/and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,11 +31,11 @@ Suggests:
     testthat
 VignetteBuilder: 
     knitr
+Remotes: 
+    rossellhayes/and
 Config/Needs/website: gadenbuie/grkgdown
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.0
-Remotes:  
-    rossellhayes/and

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,9 +55,15 @@
   `scales::label_percent()` and `{fmt(x, "$")}` will format `x` as a dollar
   figure. You can also provide your own functions (#39).
   
-* `epoxy_style_format()` is now the default transformer for all epoxy chunks,
-  making the inline `fmt()` function available in `epoxy`, `epoxy_html` and
-  `epoxy_latex` chunks (#44).
+* By default, `epoxy_style_format()` (#44) and `epoxy_style_collapse()` (#45) 
+  are now available in all epoxy chunks. This means you won't need to specify
+  the `epoxy_style` chunk option to use the inline `fmt()` function or the
+  `*`, `&`, or `|` collapse syntax.
+  
+* `epoxy_style_collapse()` now uses the [and ackage](https://and.rossellhayes.com/),
+  which provides language-aware conjoining of strings. As a result, the
+  `sep_and` and `sep_or` arguments of `epoxy_style_collapse()` are deprecated
+  and are silently ignored if provided (#45).
 
 # epoxy 0.0.2
 

--- a/R/engines.R
+++ b/R/engines.R
@@ -204,7 +204,7 @@ epoxy_options_get_transformer <- function(options) {
   if (is.vector(style) || is.list(style)) {
     return(epoxy_style(!!!style))
   }
-  style %||% options[[".transformer"]] %||% epoxy_style_format()
+  style %||% options[[".transformer"]] %||% epoxy_style("collapse", "format")
 }
 
 deprecate_glue_data_chunk_option <- function(options) {

--- a/man/epoxy_style.Rd
+++ b/man/epoxy_style.Rd
@@ -29,11 +29,9 @@ epoxy_style_code(syntax = NULL, transformer = glue::identity_transformer)
 
 epoxy_style_collapse(
   sep = ", ",
-  last = "",
-  last_and = " and ",
-  last_or = " or ",
-  sep_and = sep,
-  sep_or = sep,
+  last = sep,
+  language = NULL,
+  ...,
   transformer = glue::identity_transformer
 )
 }
@@ -49,7 +47,9 @@ other hand, \code{epoxy_style("collapse", "bold")}  will collapse the vector
 \emph{and then} embolden the entire string.
 
 In \code{epoxy_style_apply()}, the \code{...} are passed to the underlying call the
-underlying function call.}
+underlying function call.
+
+In \code{epoxy_style_collapse()}, the \code{...} are ignored.}
 
 \item{syntax}{One of \code{"markdown"} (or \code{"md"}), \code{"html"}, or \code{"latex"}. The
 default is chosen based on the engine of the chunk where the style function
@@ -68,12 +68,14 @@ the current transformation. In nearly all cases, you can let
 
 \item{.f}{A function, function name or \code{\link[purrr:map]{purrr::map()}}-style inline function.}
 
-\item{sep, sep_and, sep_or}{The separator to use when joining the vector
-elements when the variable ends in \code{*}, \code{&}, or \code{|} respectively. By
-default, these are all \code{", "}.}
+\item{sep, last}{The separator to use when joining the vector elements when
+the expression ends with a \code{*}. Elements are separated by \code{sep}, except for
+the last two elements, which use \code{last}.}
 
-\item{last, last_and, last_or}{Additional text added after \code{sep} before the
-last element when the variable ends in \code{*}, \code{&}, or \code{|} respectively.}
+\item{language}{In \code{epoxy_style_collapse()}, \code{language} is passed to
+\code{\link[and:and]{and::and()}} or \code{\link[and:and]{and::or()}} to choose the correct and/or phrase and spacing
+for the \code{language}. By default, will follow the system language. See
+\link[and:and_languages]{and::and_languages} for supported languages.}
 }
 \value{
 A function of \code{text} and \code{envir} suitable for the \code{.transformer}

--- a/tests/testthat/test-transformers.R
+++ b/tests/testthat/test-transformers.R
@@ -13,11 +13,11 @@ test_that("epoxy_style() works", {
 
   expect_equal(
     glue(
-      "{letters[1:3]&}",
+      "{letters[1:3]*}",
       .transformer = epoxy_style(
         "code",
         epoxy_style_bold,
-        epoxy_style_collapse(last_and = ", ... and ... ")
+        epoxy_style_collapse(last = ", ... and ... ")
       )
     ),
     "**`a`**, **`b`**, ... and ... **`c`**"
@@ -25,11 +25,11 @@ test_that("epoxy_style() works", {
 
   expect_equal(
     glue(
-      "{letters[1:3]&}",
+      "{letters[1:3]*}",
       .transformer = epoxy_style(
         "code",
         epoxy_style_bold,
-        epoxy_style_collapse(last_and = ", ... and ... "),
+        epoxy_style_collapse(last = ", ... and ... "),
         epoxy_style_wrap("<< ", " >>")
       )
     ),
@@ -38,10 +38,10 @@ test_that("epoxy_style() works", {
 
   expect_equal(
     glue(
-      "{letters[1:3]&}",
+      "{letters[1:3]*}",
       .transformer = epoxy_style(
         "code",
-        epoxy_style_collapse(last_and = ", ... and ... "),
+        epoxy_style_collapse(last = ", ... and ... "),
         epoxy_style_bold
       )
     ),
@@ -51,10 +51,10 @@ test_that("epoxy_style() works", {
   last_and <- ", ... and ... "
   expect_equal(
     glue(
-      "{letters[1:3]&}",
+      "{letters[1:3]*}",
       .transformer = epoxy_style(
         "code",
-        epoxy_style_collapse(last_and = last_and),
+        epoxy_style_collapse(last = last_and),
         epoxy_style_bold
       )
     ),

--- a/tests/testthat/test-transformers.R
+++ b/tests/testthat/test-transformers.R
@@ -181,3 +181,76 @@ test_that("epoxy_style_apply()", {
     "33% less than 100% is 67%"
   )
 })
+
+
+describe("epoxy_style_collapse()", {
+  it("does nothing by default", {
+    expect_equal(
+      glue("{1:3}", .transformer = epoxy_style_collapse()),
+      c("1", "2", "3")
+    )
+  })
+
+  it("collapses with custom separators", {
+    expect_equal(
+      glue("{1:3*}", .transformer = epoxy_style_collapse()),
+      "1, 2, 3"
+    )
+
+    expect_equal(
+      glue("{1:3*}", .transformer = epoxy_style_collapse(" - ")),
+      "1 - 2 - 3"
+    )
+
+    expect_equal(
+      glue("{1:3*}", .transformer = epoxy_style_collapse(" - ", "... ")),
+      "1 - 2... 3"
+    )
+  })
+
+  it("collapses with and()", {
+    expect_equal(
+      glue("{1:3&}", .transformer = epoxy_style_collapse()),
+      "1, 2, and 3"
+    )
+
+    expect_equal(
+      glue("{1:3&}", .transformer = epoxy_style_collapse(language = "es")),
+      "1, 2 y 3"
+    )
+  })
+
+  it("collapses with or()", {
+    expect_equal(
+      glue("{1:3|}", .transformer = epoxy_style_collapse()),
+      "1, 2, or 3"
+    )
+
+    expect_equal(
+      glue("{1:3|}", .transformer = epoxy_style_collapse(language = "es")),
+      "1, 2 o 3"
+    )
+  })
+
+  it("chains transformers", {
+    expect_equal(
+      glue("{1:3&}", .transformer = epoxy_style_collapse(transformer = epoxy_style_bold())),
+      "**1**, **2**, and **3**"
+    )
+
+    expect_equal(
+      glue("{1:3*}", .transformer = epoxy_style_collapse(transformer = epoxy_style_bold())),
+      "**1**, **2**, **3**"
+    )
+
+    expect_equal(
+      glue("{1:3&}", .transformer = epoxy_style_bold(transformer = epoxy_style_collapse())),
+      "**1, 2, and 3**"
+    )
+
+    expect_equal(
+      glue("{1:3*}", .transformer = epoxy_style_bold(transformer = epoxy_style_collapse())),
+      "**1, 2, 3**"
+    )
+  })
+})

--- a/tests/testthat/test-transformers.R
+++ b/tests/testthat/test-transformers.R
@@ -211,31 +211,32 @@ describe("epoxy_style_collapse()", {
   it("collapses with and()", {
     expect_equal(
       glue("{1:3&}", .transformer = epoxy_style_collapse()),
-      "1, 2, and 3"
+      and::and(1:3)
     )
 
     expect_equal(
       glue("{1:3&}", .transformer = epoxy_style_collapse(language = "es")),
-      "1, 2 y 3"
+      and::and(1:3, language = "es")
     )
   })
 
   it("collapses with or()", {
     expect_equal(
       glue("{1:3|}", .transformer = epoxy_style_collapse()),
-      "1, 2, or 3"
+      and::or(1:3)
     )
 
     expect_equal(
       glue("{1:3|}", .transformer = epoxy_style_collapse(language = "es")),
-      "1, 2 o 3"
+      and::or(1:3, language = "es")
     )
   })
 
   it("chains transformers", {
     expect_equal(
       glue("{1:3&}", .transformer = epoxy_style_collapse(transformer = epoxy_style_bold())),
-      "**1**, **2**, and **3**"
+      and::and(glue("**{1:3}**"))
+      # "**1**, **2**, and **3**"
     )
 
     expect_equal(
@@ -245,7 +246,8 @@ describe("epoxy_style_collapse()", {
 
     expect_equal(
       glue("{1:3&}", .transformer = epoxy_style_bold(transformer = epoxy_style_collapse())),
-      "**1, 2, and 3**"
+      glue("**{and::and(1:3)}**")
+      # "**1, 2, and 3**"
     )
 
     expect_equal(
@@ -257,12 +259,13 @@ describe("epoxy_style_collapse()", {
   it("is part of the default transformer", {
     expect_equal(
       glue("{1:3&}", .transformer = epoxy_options_get_transformer(list())),
-      "1, 2, and 3"
+      and::and(1:3)
     )
 
     expect_equal(
       glue("{fmt(1:3 + 0.25 * 1:3, '$')&}", .transformer = epoxy_options_get_transformer(list())),
-      "$1.25, $2.50, and $3.75"
+      and::and(c("$1.25", "$2.50", "$3.75"))
+      # "$1.25, $2.50, and $3.75"
     )
   })
 })

--- a/tests/testthat/test-transformers.R
+++ b/tests/testthat/test-transformers.R
@@ -253,4 +253,16 @@ describe("epoxy_style_collapse()", {
       "**1, 2, 3**"
     )
   })
+
+  it("is part of the default transformer", {
+    expect_equal(
+      glue("{1:3&}", .transformer = epoxy_options_get_transformer(list())),
+      "1, 2, and 3"
+    )
+
+    expect_equal(
+      glue("{fmt(1:3 + 0.25 * 1:3, '$')&}", .transformer = epoxy_options_get_transformer(list())),
+      "$1.25, $2.50, and $3.75"
+    )
+  })
 })


### PR DESCRIPTION
- Use {and} for epoxy_style_collapse()
- Make format + collapse the default transformer
