### PR TITLE
Use dot-prefixed arguments in`epoxy_transform_inline()`

### DIFF
--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -13,9 +13,9 @@
 #' epoxy("It cost {.dollar 123456}.", .transformer = "inline")
 #' ```
 #'
-#' The formatters, e.g. `dollar` in the example above, can be customized using
+#' The formatters, e.g. `.dollar` in the example above, can be customized using
 #' the arguments of `epoxy_transform_inline()`. Pass a customized
-#' [scales::label_dollar()] to `dollar` to achieve a different transformation.
+#' [scales::label_dollar()] to `.dollar` to achieve a different transformation.
 #'
 #' ```{r}
 #' dollars_nzd <- scales::label_dollar(suffix = " NZD")
@@ -62,7 +62,8 @@
 #'
 #' @param ... Additional named inline transformers as functions taking at least
 #'   one argument. The evaluated expression from the template expression is
-#'   passed as the first argument to the function.
+#'   passed as the first argument to the function. The argument names must
+#'   include the leading `.` to match the syntax used inline.
 #' @param transformer The transformer to apply to the replacement string. This
 #'   argument is used for chaining the transformer functions. By providing a
 #'   function to this argument you can apply an additional transformation after

--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -196,7 +196,7 @@ epoxy_transform_inline <- function(
 		}
 
 		text_fn <-
-		  if (class %in% names(fmts_defaults)) {
+			if (class %in% names(fmts_defaults)) {
 				fmts_defaults[[class]]
 			} else {
 				maybe_custom_class
@@ -261,20 +261,20 @@ epoxy_transform_inline_defaults <- function() {
 }
 
 epoxy_transform_inline_add_aliases <- function(fmts) {
-  apply_if_missing_but_has <- function(miss, has) {
-    if (!miss %in% names(fmts) && has %in% names(fmts)) {
+	apply_if_missing_but_has <- function(miss, has) {
+		if (!miss %in% names(fmts) && has %in% names(fmts)) {
 			fmts[[miss]] <<- fmts[[has]]
 		}
-  }
-  apply_if_missing_but_has(".bold", ".strong")
-  apply_if_missing_but_has(".italic", ".emph")
-  apply_if_missing_but_has(".dttm", ".datetime")
-  apply_if_missing_but_has(".num", ".number")
-  apply_if_missing_but_has(".pct", ".percent")
-  apply_if_missing_but_has(".lc", ".lowercase")
-  apply_if_missing_but_has(".uc", ".uppercase")
-  apply_if_missing_but_has(".tc", ".titlecase")
-  fmts
+	}
+	apply_if_missing_but_has(".bold", ".strong")
+	apply_if_missing_but_has(".italic", ".emph")
+	apply_if_missing_but_has(".dttm", ".datetime")
+	apply_if_missing_but_has(".num", ".number")
+	apply_if_missing_but_has(".pct", ".percent")
+	apply_if_missing_but_has(".lc", ".lowercase")
+	apply_if_missing_but_has(".uc", ".uppercase")
+	apply_if_missing_but_has(".tc", ".titlecase")
+	fmts
 }
 
 epoxy_comma <- function(comma_numeric) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,3 +64,7 @@ list_split_named <- function(l) {
 		named = l[nzchar(names(l))]
 	)
 }
+
+discard_null <- function(x) {
+	x[!vapply(x, is.null, logical(1))]
+}

--- a/man/epoxy_transform.Rd
+++ b/man/epoxy_transform.Rd
@@ -97,7 +97,7 @@ epoxy("{.number amount}")
 epoxy(
   "{.number amount}",
   .transformer = epoxy_transform_inline(
-    number = scales::label_number(accuracy = 0.01)
+    .number = scales::label_number(accuracy = 0.01)
   )
 )
 

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -35,7 +35,8 @@ epoxy_transform_inline(
 \arguments{
 \item{...}{Additional named inline transformers as functions taking at least
 one argument. The evaluated expression from the template expression is
-passed as the first argument to the function.}
+passed as the first argument to the function. The argument names must
+include the leading \code{.} to match the syntax used inline.}
 
 \item{transformer}{The transformer to apply to the replacement string. This
 argument is used for chaining the transformer functions. By providing a
@@ -108,9 +109,9 @@ in place.
 #> It cost $123,456.
 }\if{html}{\out{</div>}}
 
-The formatters, e.g. \code{dollar} in the example above, can be customized using
+The formatters, e.g. \code{.dollar} in the example above, can be customized using
 the arguments of \code{epoxy_transform_inline()}. Pass a customized
-\code{\link[scales:label_dollar]{scales::label_dollar()}} to \code{dollar} to achieve a different transformation.
+\code{\link[scales:label_dollar]{scales::label_dollar()}} to \code{.dollar} to achieve a different transformation.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{dollars_nzd <- scales::label_dollar(suffix = " NZD")
 

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -150,7 +150,7 @@ epoxy(
     .runif = function(n) sort(runif(n))
   )
 )
-#> Here are three random percentages: 23\%, 35\%, and 99\%.
+#> Here are three random percentages: 23\%, 35\% and 99\%.
 }\if{html}{\out{</div>}}
 }
 \examples{

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -7,29 +7,29 @@
 epoxy_transform_inline(
   ...,
   transformer = glue::identity_transformer,
-  and = and::and,
-  or = and::or,
-  incr = sort,
-  decr = function(x) sort(x, decreasing = TRUE),
-  bytes = scales::label_bytes(),
-  date = function(x) format(x, format = "\%F"),
-  time = function(x) format(x, format = "\%T"),
-  datetime = function(x) format(x, format = "\%F \%T"),
-  dollar = scales::label_dollar(prefix = engine_pick("$", "$", "\\\\$")),
-  number = scales::label_number(),
-  comma = scales::label_comma(),
-  ordinal = scales::label_ordinal(),
-  percent = scales::label_percent(suffix = engine_pick("\%", "\%", "\\\\\%")),
-  pvalue = scales::label_pvalue(),
-  scientific = scales::label_scientific(),
-  uppercase = toupper,
-  lowercase = tolower,
-  titlecase = tools::toTitleCase,
-  squote = function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
-  dquote = function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
-  strong = NULL,
-  emph = NULL,
-  code = NULL
+  .and = and::and,
+  .or = and::or,
+  .incr = sort,
+  .decr = function(x) sort(x, decreasing = TRUE),
+  .bytes = scales::label_bytes(),
+  .date = function(x) format(x, format = "\%F"),
+  .time = function(x) format(x, format = "\%T"),
+  .datetime = function(x) format(x, format = "\%F \%T"),
+  .dollar = scales::label_dollar(prefix = engine_pick("$", "$", "\\\\$")),
+  .number = scales::label_number(),
+  .comma = scales::label_comma(),
+  .ordinal = scales::label_ordinal(),
+  .percent = scales::label_percent(suffix = engine_pick("\%", "\%", "\\\\\%")),
+  .pvalue = scales::label_pvalue(),
+  .scientific = scales::label_scientific(),
+  .uppercase = toupper,
+  .lowercase = tolower,
+  .titlecase = tools::toTitleCase,
+  .squote = function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
+  .dquote = function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
+  .strong = NULL,
+  .emph = NULL,
+  .code = NULL
 )
 }
 \arguments{
@@ -44,51 +44,51 @@ the current transformation. In nearly all cases, you can let
 \code{epoxy_transform()} handle this for you. The chain ends when
 \code{\link[glue:identity_transformer]{glue::identity_transformer()}} is used as the \code{transformer}.}
 
-\item{and}{The function to apply to \code{x} when the template is \verb{\{.and x\}}. Default is \code{\link[and:and]{and::and()}}.}
+\item{.and}{The function to apply to \code{x} when the template is \verb{\{..and x\}}. Default is \code{\link[and:and]{and::and()}}.}
 
-\item{or}{The function to apply to \code{x} when the template is \verb{\{.or x\}}. Default is \code{\link[and:and]{and::or()}}.}
+\item{.or}{The function to apply to \code{x} when the template is \verb{\{..or x\}}. Default is \code{\link[and:and]{and::or()}}.}
 
-\item{incr}{The function to apply to \code{x} when the template is \verb{\{.incr x\}}. Default is \code{\link[=sort]{sort()}}.}
+\item{.incr}{The function to apply to \code{x} when the template is \verb{\{..incr x\}}. Default is \code{\link[=sort]{sort()}}.}
 
-\item{decr}{The function to apply to \code{x} when the template is \verb{\{.decr x\}}. Default is \code{function(x) sort(x, decreasing = TRUE)}.}
+\item{.decr}{The function to apply to \code{x} when the template is \verb{\{..decr x\}}. Default is \code{function(x) sort(x, decreasing = TRUE)}.}
 
-\item{bytes}{The function to apply to \code{x} when the template is \verb{\{.bytes x\}}. Default is scales::label_bytes().}
+\item{.bytes}{The function to apply to \code{x} when the template is \verb{\{..bytes x\}}. Default is scales::label_bytes().}
 
-\item{date}{The function to apply to \code{x} when the template is \verb{\{.date x\}}. Default is \code{function(x) format(x, format = "\%F")}.}
+\item{.date}{The function to apply to \code{x} when the template is \verb{\{..date x\}}. Default is \code{function(x) format(x, format = "\%F")}.}
 
-\item{time}{The function to apply to \code{x} when the template is \verb{\{.time x\}}. Default is \code{function(x) format(x, format = "\%T")}.}
+\item{.time}{The function to apply to \code{x} when the template is \verb{\{..time x\}}. Default is \code{function(x) format(x, format = "\%T")}.}
 
-\item{datetime}{The function to apply to \code{x} when the template is \verb{\{.datetime x\}} or \verb{\{.dttm x\}}. Default is \code{function(x) format(x, format = "\%F \%T")}.}
+\item{.datetime}{The function to apply to \code{x} when the template is \verb{\{..datetime x\}}. Default is \code{function(x) format(x, format = "\%F \%T")}.}
 
-\item{dollar}{The function to apply to \code{x} when the template is \verb{\{.dollar x\}}. Default is scales::label_dollar().}
+\item{.dollar}{The function to apply to \code{x} when the template is \verb{\{..dollar x\}}. Default is scales::label_dollar().}
 
-\item{number}{The function to apply to \code{x} when the template is \verb{\{.number x\}} or \verb{\{.num x\}}. Default is scales::label_number().}
+\item{.number}{The function to apply to \code{x} when the template is \verb{\{..number x\}}. Default is scales::label_number().}
 
-\item{comma}{The function to apply to \code{x} when the template is \verb{\{.comma x\}}. Default is scales::label_comma().}
+\item{.comma}{The function to apply to \code{x} when the template is \verb{\{..comma x\}}. Default is scales::label_comma().}
 
-\item{ordinal}{The function to apply to \code{x} when the template is \verb{\{.ordinal x\}}. Default is scales::label_ordinal().}
+\item{.ordinal}{The function to apply to \code{x} when the template is \verb{\{..ordinal x\}}. Default is scales::label_ordinal().}
 
-\item{percent}{The function to apply to \code{x} when the template is \verb{\{.percent x\}} or \verb{\{.pct x\}}. Default is scales::label_percent().}
+\item{.percent}{The function to apply to \code{x} when the template is \verb{\{..percent x\}}. Default is scales::label_percent().}
 
-\item{pvalue}{The function to apply to \code{x} when the template is \verb{\{.pvalue x\}}. Default is scales::label_pvalue().}
+\item{.pvalue}{The function to apply to \code{x} when the template is \verb{\{..pvalue x\}}. Default is scales::label_pvalue().}
 
-\item{scientific}{The function to apply to \code{x} when the template is \verb{\{.scientific x\}}. Default is scales::label_scientific().}
+\item{.scientific}{The function to apply to \code{x} when the template is \verb{\{..scientific x\}}. Default is scales::label_scientific().}
 
-\item{uppercase}{The function to apply to \code{x} when the template is \verb{\{.uppercase x\}} or \verb{\{.uc x\}}. Default is \code{\link[=toupper]{toupper()}}.}
+\item{.uppercase}{The function to apply to \code{x} when the template is \verb{\{..uppercase x\}}. Default is \code{\link[=toupper]{toupper()}}.}
 
-\item{lowercase}{The function to apply to \code{x} when the template is \verb{\{.lowercase x\}} or \verb{\{.lo x\}}. Default is \code{\link[=tolower]{tolower()}}.}
+\item{.lowercase}{The function to apply to \code{x} when the template is \verb{\{..lowercase x\}}. Default is \code{\link[=tolower]{tolower()}}.}
 
-\item{titlecase}{The function to apply to \code{x} when the template is \verb{\{.titlecase x\}} or \verb{\{.tc x\}}. Default is \code{\link[tools:toTitleCase]{tools::toTitleCase()}}.}
+\item{.titlecase}{The function to apply to \code{x} when the template is \verb{\{..titlecase x\}}. Default is \code{\link[tools:toTitleCase]{tools::toTitleCase()}}.}
 
-\item{squote}{The function to apply to \code{x} when the template is \verb{\{.squote x\}}. Default is \code{function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
+\item{.squote}{The function to apply to \code{x} when the template is \verb{\{..squote x\}}. Default is \code{function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
 
-\item{dquote}{The function to apply to \code{x} when the template is \verb{\{.dquote x\}}. Default is \code{function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
+\item{.dquote}{The function to apply to \code{x} when the template is \verb{\{..dquote x\}}. Default is \code{function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
 
-\item{strong}{The function to apply to \code{x} when the template is \verb{\{.strong x\}} or \verb{\{.bold x\}}. Default is chosen internally based on the output format.}
+\item{.strong}{The function to apply to \code{x} when the template is \verb{\{..strong x\}}. Default is chosen internally based on the output format.}
 
-\item{emph}{The function to apply to \code{x} when the template is \verb{\{.emph x\}} or \verb{\{.italic x\}}. Default is chosen internally based on the output format.}
+\item{.emph}{The function to apply to \code{x} when the template is \verb{\{..emph x\}}. Default is chosen internally based on the output format.}
 
-\item{code}{The function to apply to \code{x} when the template is \verb{\{.code x\}}. Default is chosen internally based on the output format.}
+\item{.code}{The function to apply to \code{x} when the template is \verb{\{..code x\}}. Default is chosen internally based on the output format.}
 }
 \value{
 A function of \code{text} and \code{envir} suitable for the \code{.transformer} argument of
@@ -116,7 +116,7 @@ the arguments of \code{epoxy_transform_inline()}. Pass a customized
 
 epoxy(
   "It cost \{.dollar 123456\}.",
-  .transformer = epoxy_transform_inline(dollar = dollars_nzd)
+  .transformer = epoxy_transform_inline(.dollar = dollars_nzd)
 )
 #> It cost $123,456 NZD.
 }\if{html}{\out{</div>}}
@@ -147,10 +147,10 @@ expression. In this example, I add a \code{.runif} inline formatter that generat
 epoxy(
   "Here are three random percentages: \{.and \{.pct \{.runif 3\}\}\}.",
   .transformer = epoxy_transform_inline(
-    runif = function(n) sort(runif(n))
+    .runif = function(n) sort(runif(n))
   )
 )
-#> Here are three random percentages: 23\%, 35\% and 99\%.
+#> Here are three random percentages: 23\%, 35\%, and 99\%.
 }\if{html}{\out{</div>}}
 }
 \examples{
@@ -174,16 +174,16 @@ glue::glue(
 epoxy(
   '{.pct revenue} of revenue generates {.dollar sales} in profits.',
   .transformer = epoxy_transform_inline(
-    percent = scales::label_percent(accuracy = 0.1),
-    dollar = scales::label_dollar(accuracy = 10)
+    .percent = scales::label_percent(accuracy = 0.1),
+    .dollar = scales::label_dollar(accuracy = 10)
   )
 )
 
 glue::glue(
   '{.pct revenue} of revenue generates {.dollar sales} in profits.',
   .transformer = epoxy_transform_inline(
-    percent = scales::label_percent(accuracy = 0.1),
-    dollar = scales::label_dollar(accuracy = 10)
+    .percent = scales::label_percent(accuracy = 0.1),
+    .dollar = scales::label_dollar(accuracy = 10)
   )
 )
 
@@ -194,7 +194,7 @@ search <- "why are cats scared of cucumbers"
 epoxy_html(
   "https://example.com?q={{ .url_encode search }}>",
   .transformer = epoxy_transform_inline(
-    url_encode = utils::URLencode
+    .url_encode = utils::URLencode
   )
 )
 }

--- a/man/examples/epoxy_transform.R
+++ b/man/examples/epoxy_transform.R
@@ -19,7 +19,7 @@ epoxy("{.number amount}")
 epoxy(
   "{.number amount}",
   .transformer = epoxy_transform_inline(
-    number = scales::label_number(accuracy = 0.01)
+    .number = scales::label_number(accuracy = 0.01)
   )
 )
 

--- a/man/examples/epoxy_transform_inline.R
+++ b/man/examples/epoxy_transform_inline.R
@@ -18,16 +18,16 @@ glue::glue(
 epoxy(
   '{.pct revenue} of revenue generates {.dollar sales} in profits.',
   .transformer = epoxy_transform_inline(
-    percent = scales::label_percent(accuracy = 0.1),
-    dollar = scales::label_dollar(accuracy = 10)
+    .percent = scales::label_percent(accuracy = 0.1),
+    .dollar = scales::label_dollar(accuracy = 10)
   )
 )
 
 glue::glue(
   '{.pct revenue} of revenue generates {.dollar sales} in profits.',
   .transformer = epoxy_transform_inline(
-    percent = scales::label_percent(accuracy = 0.1),
-    dollar = scales::label_dollar(accuracy = 10)
+    .percent = scales::label_percent(accuracy = 0.1),
+    .dollar = scales::label_dollar(accuracy = 10)
   )
 )
 
@@ -38,6 +38,6 @@ search <- "why are cats scared of cucumbers"
 epoxy_html(
   "https://example.com?q={{ .url_encode search }}>",
   .transformer = epoxy_transform_inline(
-    url_encode = utils::URLencode
+    .url_encode = utils::URLencode
   )
 )

--- a/tests/testthat/test-epoxy_transform_inline.R
+++ b/tests/testthat/test-epoxy_transform_inline.R
@@ -17,19 +17,29 @@ describe("epoxy_transform_inline()", {
 			epoxy(
 				"{ .test letters }",
 				.transformer = epoxy_transform_inline(
-					test = function(x) "PASS"
+					.test = function(x) "PASS"
 				)
 			),
 			"PASS"
 		)
 	})
 
-	it("applies user-supplied format when it's an internal alias", {
+	it("applies user-supplied format over-riding internal alias", {
 		expect_equal(
 			epoxy(
 				"{ .bold letters[1] }",
 				.transformer = epoxy_transform_inline(
-					bold = function(x) "PASS"
+					.bold = function(x) "PASS"
+				)
+			),
+			"PASS"
+		)
+
+		expect_equal(
+			epoxy(
+				"{ .bold letters[1] }",
+				.transformer = epoxy_transform_inline(
+					.strong = function(x) "PASS"
 				)
 			),
 			"PASS"
@@ -39,7 +49,7 @@ describe("epoxy_transform_inline()", {
 			epoxy(
 				"{ .strong letters[1] }",
 				.transformer = epoxy_transform_inline(
-					bold = function(x) "PASS"
+					.bold = function(x) "PASS"
 				)
 			),
 			"**a**"


### PR DESCRIPTION
Fixes #90

Renames all of the arguments of `epoxy_transform_inline()` so that transformation functions always start with dots. This improves consistency (use `.dollar` inline and as the argument name).

And rewrite how inline formatters are handled in prep for external default setting to come for #89.