### PR TITLE
Add a `.data` pronoun

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # epoxy (development version)
 
+* `epoxy()` now adds a `.data` pronoun that allows you to refer to the list or
+  data frame passed into either the `.data` argument of `epoxy()` or the `data`
+  or `.data` chunk options. (#100)
+
 # epoxy 0.1.1
 
 * `epoxy_transform_html()` now (again) returns a collapsed character string for

--- a/R/epoxy.R
+++ b/R/epoxy.R
@@ -82,6 +82,7 @@ epoxy <- function(
 	if (!is.null(.data)) {
 		glue_env <- new.env(parent = .envir)
 		assign("$", epoxy_data_subset, envir = glue_env)
+		assign(".data", .data, envir = glue_env)
 	}
 
 	opts_transformer <- list(

--- a/R/epoxy.R
+++ b/R/epoxy.R
@@ -193,9 +193,16 @@ with_epoxy_engine <- function(engine, expr) {
 
 epoxy_data_subset <- function(x, y) {
 	y <- substitute(y)
-	x <- lapply(x, function(.x) base::`[[`(.x, y))
-	x_len_1 <- vapply(x, function(x) length(x) == 1, logical(1))
-	if (all(x_len_1)) unlist(x) else x
+	if (identical(deparse(substitute(x)), ".data")) {
+		return(base::`[[`(x, y, exact = FALSE))
+	}
+
+	ret <- tryCatch(base::`[[`(x, y, exact = FALSE), error = function(...) NULL)
+	if (!is.null(ret)) return(ret)
+
+	z <- lapply(x, function(.x) base::`[[`(.x, y, exact = FALSE))
+	z_len_1 <- vapply(z, function(z) length(z) == 1, logical(1))
+	if (all(z_len_1)) unlist(z) else z
 }
 
 epoxy_options_get_transformer <- function(options) {

--- a/R/epoxy.R
+++ b/R/epoxy.R
@@ -193,14 +193,16 @@ with_epoxy_engine <- function(engine, expr) {
 
 epoxy_data_subset <- function(x, y) {
 	y <- substitute(y)
+	exact <- inherits(x, "tbl_df")
+
 	if (identical(deparse(substitute(x)), ".data")) {
-		return(base::`[[`(x, y, exact = FALSE))
+		return(base::`[[`(x, y, exact = exact))
 	}
 
-	ret <- tryCatch(base::`[[`(x, y, exact = FALSE), error = function(...) NULL)
+	ret <- tryCatch(base::`[[`(x, y, exact = exact), error = function(...) NULL)
 	if (!is.null(ret)) return(ret)
 
-	z <- lapply(x, function(.x) base::`[[`(.x, y, exact = FALSE))
+	z <- lapply(x, function(.x) base::`[[`(.x, y, exact = exact))
 	z_len_1 <- vapply(z, function(z) length(z) == 1, logical(1))
 	if (all(z_len_1)) unlist(z) else z
 }

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ and it features movie stars
 <blockquote>
 The movie *Back to the Future Part II* was released in **1989**. It
 earned \$118,450,002 with a budget of \$40,000,000, and it features
-movie stars Michael J. Fox, Christopher Lloyd, Lea Thompson and Thomas
+movie stars Michael J. Fox, Christopher Lloyd, Lea Thompson, and Thomas
 F. Wilson.
 </blockquote>
 

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -151,7 +151,7 @@ epoxy(
     .runif = function(n) sort(runif(n))
   )
 )
-#> Here are three random percentages: 23\%, 35\% and 99\%.
+#> Here are three random percentages: 23\%, 35\%, and 99\%.
 }\if{html}{\out{</div>}}
 }
 \examples{

--- a/tests/testthat/_snaps/transformers.md
+++ b/tests/testthat/_snaps/transformers.md
@@ -1,4 +1,4 @@
 # engine_validate_alias(): errors with unknown engine names
 
-    'unknown' is not a valid engine name (language syntax). Valid choices include `md`, `markdown`, `glue`, `epoxy`, `html`, `glue_html`, `epoxy_html`, `latex`, `glue_latex` or `epoxy_latex`.
+    'unknown' is not a valid engine name (language syntax). Valid choices include `md`, `markdown`, `glue`, `epoxy`, `html`, `glue_html`, `epoxy_html`, `latex`, `glue_latex`, or `epoxy_latex`.
 

--- a/tests/testthat/test-epoxy.R
+++ b/tests/testthat/test-epoxy.R
@@ -12,7 +12,7 @@ test_that("epoxy .data pronoun", {
 	expect_equal(
 		epoxy(
 			"{.comma unlist(.data[c('b', 'a')])}",
-		  .data = list(a = "hi", b = "there")
+			.data = list(a = "hi", b = "there")
 		),
 		glue("there, hi")
 	)

--- a/tests/testthat/test-epoxy.R
+++ b/tests/testthat/test-epoxy.R
@@ -18,6 +18,35 @@ test_that("epoxy .data pronoun", {
 	)
 })
 
+test_that("epoxy_data_subset()", {
+	nested <- list(
+		outer = list(
+			list(inner = "one"),
+			list(inner = "two")
+		),
+		flat = list(inner = "flat"),
+		ragged = list(
+			list(inner = c("one", "two")),
+			list(inner = "three")
+		)
+	)
+
+	expect_equal(
+		epoxy("{.comma outer$inner}", .data = nested),
+		glue("one, two")
+	)
+
+	expect_equal(
+		epoxy("{flat$inner}", .data = nested),
+		glue("flat")
+	)
+
+	expect_equal(
+		epoxy("{ragged$inner[[1]][2]}", .data = nested),
+		glue("two")
+	)
+})
+
 describe("epoxy_html()", {
 	it("returns an html glue character", {
 		expect_s3_class(

--- a/tests/testthat/test-epoxy.R
+++ b/tests/testthat/test-epoxy.R
@@ -1,3 +1,23 @@
+test_that("epoxy .data pronoun", {
+	expect_equal(
+		epoxy("{.data}", .data = list(a = "hi", b = "there")),
+		glue('{list(a = "hi", b = "there")}')
+	)
+
+	expect_equal(
+		epoxy("{.data$a}", .data = list(a = "hi", b = "there")),
+		glue("hi")
+	)
+
+	expect_equal(
+		epoxy(
+			"{.comma unlist(.data[c('b', 'a')])}",
+		  .data = list(a = "hi", b = "there")
+		),
+		glue("there, hi")
+	)
+})
+
 describe("epoxy_html()", {
 	it("returns an html glue character", {
 		expect_s3_class(


### PR DESCRIPTION
Adds a `.data` pronoun that allows you to refer to the list or data frame passed into the `.data` argument of `epoxy()` or the `data` or `.data` chunk options.

``` r
library(epoxy)

kable_top <- function(x) {
    paste(knitr::kable(head(x)), collapse = '\n')
}

epoxy_transform_set(.kable_top = kable_top)

epoxy("{.kable_top .data}", .data = mtcars)
#> |                  |  mpg| cyl| disp|  hp| drat|    wt|  qsec| vs| am| gear| carb|
#> |:-----------------|----:|---:|----:|---:|----:|-----:|-----:|--:|--:|----:|----:|
#> |Mazda RX4         | 21.0|   6|  160| 110| 3.90| 2.620| 16.46|  0|  1|    4|    4|
#> |Mazda RX4 Wag     | 21.0|   6|  160| 110| 3.90| 2.875| 17.02|  0|  1|    4|    4|
#> |Datsun 710        | 22.8|   4|  108|  93| 3.85| 2.320| 18.61|  1|  1|    4|    1|
#> |Hornet 4 Drive    | 21.4|   6|  258| 110| 3.08| 3.215| 19.44|  1|  0|    3|    1|
#> |Hornet Sportabout | 18.7|   8|  360| 175| 3.15| 3.440| 17.02|  0|  0|    3|    2|
#> |Valiant           | 18.1|   6|  225| 105| 2.76| 3.460| 20.22|  1|  0|    3|    1|
```

`epoxy()` also masks `$` to make it easier to recurse into nested lists and this PR improves the custom behavior of `$`.