### PR TITLE
feat(epoxy_transform_inline): Add `.sentence` transformer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ URL: https://pkg.garrickadenbuie.com/epoxy/,
     https://github.com/gadenbuie/epoxy
 BugReports: https://github.com/gadenbuie/epoxy/issues
 Depends:
-    R (>= 2.10)
+    R (>= 3.6.0)
 Imports:
     and,
     glue (>= 1.5.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,11 @@
   change was necessary to allow the `expr` to include common R operators like
   `<` and `>`. (#107)
 
+* Aded `.sentence` (alias `.sc`) to the list of inline transformers provided by
+  `epoxy_transform_inline()`. This transformer will capitalize the first letter
+  of the first word in the expression. This is useful when you want to need to
+  start a sentence with a variable that may contain more than one word. (#112)
+
 # epoxy 0.1.1
 
 * `epoxy_transform_html()` now (again) returns a collapsed character string for

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,10 @@
   of the first word in the expression. This is useful when you want to need to
   start a sentence with a variable that may contain more than one word. (#112)
 
+* The `.titlecase` inline transformer now coerces inputs to character with
+  `as.character()` before applying `tools::toTitleCase()`, since `toTitleCase()`
+  will throw an error for non-character inputs. (#112)
+
 # epoxy 0.1.1
 
 * `epoxy_transform_html()` now (again) returns a collapsed character string for

--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -359,7 +359,7 @@ roxy_inline_params <- function() {
 		uc     = "uppercase",
 		lo     = "lowercase",
 		tc     = "titlecase",
-		sc 	   = "sentence"
+		sc         = "sentence"
 	)
 
 	values <- purrr::map_chr(names(args), function(label) {

--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -292,7 +292,7 @@ epoxy_inline_aliases <- c(
 )
 
 epoxy_transform_inline_add_aliases <- function(fmts) {
-  aliases <- epoxy_inline_aliases
+	aliases <- epoxy_inline_aliases
 	aliases <- aliases[aliases %in% names(fmts)]
 
 	for (i in seq_along(aliases)) {

--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -279,21 +279,30 @@ epoxy_transform_inline_defaults <- function() {
 	defaults
 }
 
+epoxy_inline_aliases <- c(
+	.bold   = ".strong",
+	.italic = ".emph",
+	.dttm   = ".datetime",
+	.num    = ".number",
+	.pct    = ".percent",
+	.uc     = ".uppercase",
+	.lc     = ".lowercase",
+	.tc     = ".titlecase",
+	.sc     = ".sentence"
+)
+
 epoxy_transform_inline_add_aliases <- function(fmts) {
-	apply_if_missing_but_has <- function(miss, has) {
-		if (!miss %in% names(fmts) && has %in% names(fmts)) {
-			fmts[[miss]] <<- fmts[[has]]
+  aliases <- epoxy_inline_aliases
+	aliases <- aliases[aliases %in% names(fmts)]
+
+	for (i in seq_along(aliases)) {
+		alias <- names(aliases)[i]
+		impl <- aliases[[i]]
+		if (!alias %in% names(fmts) && impl %in% names(fmts)) {
+			fmts[[alias]] <- fmts[[impl]]
 		}
 	}
-	apply_if_missing_but_has(".bold", ".strong")
-	apply_if_missing_but_has(".italic", ".emph")
-	apply_if_missing_but_has(".dttm", ".datetime")
-	apply_if_missing_but_has(".num", ".number")
-	apply_if_missing_but_has(".pct", ".percent")
-	apply_if_missing_but_has(".lc", ".lowercase")
-	apply_if_missing_but_has(".uc", ".uppercase")
-	apply_if_missing_but_has(".tc", ".titlecase")
-	apply_if_missing_but_has(".sc", ".sentence")
+
 	fmts
 }
 
@@ -350,21 +359,11 @@ roxy_inline_params <- function() {
 		paste0("[", expr, "()]")
 	})
 
-	extras <- c(
-		bold   = "strong",
-		italic = "emph",
-		dttm   = "datetime",
-		num    = "number",
-		pct    = "percent",
-		uc     = "uppercase",
-		lo     = "lowercase",
-		tc     = "titlecase",
-		sc         = "sentence"
-	)
+	extras <- epoxy_inline_aliases
 
 	values <- purrr::map_chr(names(args), function(label) {
 		label <- c(label, names(extras[extras == label]))
-		knitr::combine_words(label, before = "`{.", after = " x}`", and = " or ")
+		knitr::combine_words(label, before = "`{", after = " x}`", and = " or ")
 	})
 
 	glue(

--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -97,6 +97,7 @@ epoxy_transform_inline <- function(
 	.uppercase   = toupper,
 	.lowercase   = tolower,
 	.titlecase   = tools::toTitleCase,
+	.sentence    = function(x) `substr<-`(x, 1, 1, toupper(substr(x, 1, 1))),
 	.squote      = function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
 	.dquote      = function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
 	.strong      = NULL,
@@ -292,6 +293,7 @@ epoxy_transform_inline_add_aliases <- function(fmts) {
 	apply_if_missing_but_has(".lc", ".lowercase")
 	apply_if_missing_but_has(".uc", ".uppercase")
 	apply_if_missing_but_has(".tc", ".titlecase")
+	apply_if_missing_but_has(".sc", ".sentence")
 	fmts
 }
 
@@ -356,7 +358,8 @@ roxy_inline_params <- function() {
 		pct    = "percent",
 		uc     = "uppercase",
 		lo     = "lowercase",
-		tc     = "titlecase"
+		tc     = "titlecase",
+		sc 	   = "sentence"
 	)
 
 	values <- purrr::map_chr(names(args), function(label) {

--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -96,7 +96,7 @@ epoxy_transform_inline <- function(
 	.scientific  = scales::label_scientific(),
 	.uppercase   = toupper,
 	.lowercase   = tolower,
-	.titlecase   = tools::toTitleCase,
+	.titlecase   = function(x) tools::toTitleCase(as.character(x)),
 	.sentence    = function(x) `substr<-`(x, 1, 1, toupper(substr(x, 1, 1))),
 	.squote      = function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
 	.dquote      = function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),

--- a/R/epoxy_transform_inline.R
+++ b/R/epoxy_transform_inline.R
@@ -350,13 +350,16 @@ roxy_inline_params <- function() {
 			return("chosen internally based on the output format")
 		}
 		if (grepl("^function", expr)) {
-			return(paste0("`", expr, "`"))
+			# internal defaults, defined in the function signature
+			return(paste("``", expr, "``"))
 		}
-		expr <- sub("\\(.+\\)$", "()", expr)
-		if (grepl("\\(\\)$", expr)) {
-			return(expr)
+		if (!grepl("\\(.*\\)", expr)) {
+			# default is a function, e.g. and::and
+			return(sprintf("[%s()]", expr))
 		}
-		paste0("[", expr, "()]")
+		# default is a function call, maybe with arguments
+		link <- sub("\\(.*\\)$", "", expr)
+		return(sprintf("[%s][%s]", expr, link))
 	})
 
 	extras <- epoxy_inline_aliases

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -25,6 +25,7 @@ epoxy_transform_inline(
   .uppercase = toupper,
   .lowercase = tolower,
   .titlecase = tools::toTitleCase,
+  .sentence = function(x) `substr<-`(x, 1, 1, toupper(substr(x, 1, 1))),
   .squote = function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
   .dquote = function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
   .strong = NULL,
@@ -80,6 +81,8 @@ the current transformation. In nearly all cases, you can let
 \item{.lowercase}{The function to apply to \code{x} when the template is \verb{\{..lowercase x\}}. Default is \code{\link[=tolower]{tolower()}}.}
 
 \item{.titlecase}{The function to apply to \code{x} when the template is \verb{\{..titlecase x\}}. Default is \code{\link[tools:toTitleCase]{tools::toTitleCase()}}.}
+
+\item{.sentence}{The function to apply to \code{x} when the template is \verb{\{..sentence x\}}. Default is \verb{function(x) }substr<-\verb{(x, 1, 1, toupper(substr(x, 1, 1)))}.}
 
 \item{.squote}{The function to apply to \code{x} when the template is \verb{\{..squote x\}}. Default is \code{function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
 

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -46,53 +46,53 @@ the current transformation. In nearly all cases, you can let
 \code{epoxy_transform()} handle this for you. The chain ends when
 \code{\link[glue:identity_transformer]{glue::identity_transformer()}} is used as the \code{transformer}.}
 
-\item{.and}{The function to apply to \code{x} when the template is \verb{\{..and x\}}. Default is \code{\link[and:and]{and::and()}}.}
+\item{.and}{The function to apply to \code{x} when the template is \verb{\{.and x\}}. Default is \code{\link[and:and]{and::and()}}.}
 
-\item{.or}{The function to apply to \code{x} when the template is \verb{\{..or x\}}. Default is \code{\link[and:and]{and::or()}}.}
+\item{.or}{The function to apply to \code{x} when the template is \verb{\{.or x\}}. Default is \code{\link[and:and]{and::or()}}.}
 
-\item{.incr}{The function to apply to \code{x} when the template is \verb{\{..incr x\}}. Default is \code{\link[=sort]{sort()}}.}
+\item{.incr}{The function to apply to \code{x} when the template is \verb{\{.incr x\}}. Default is \code{\link[=sort]{sort()}}.}
 
-\item{.decr}{The function to apply to \code{x} when the template is \verb{\{..decr x\}}. Default is \code{function(x) sort(x, decreasing = TRUE)}.}
+\item{.decr}{The function to apply to \code{x} when the template is \verb{\{.decr x\}}. Default is \code{function(x) sort(x, decreasing = TRUE)}.}
 
-\item{.bytes}{The function to apply to \code{x} when the template is \verb{\{..bytes x\}}. Default is scales::label_bytes().}
+\item{.bytes}{The function to apply to \code{x} when the template is \verb{\{.bytes x\}}. Default is scales::label_bytes().}
 
-\item{.date}{The function to apply to \code{x} when the template is \verb{\{..date x\}}. Default is \code{function(x) format(x, format = "\%F")}.}
+\item{.date}{The function to apply to \code{x} when the template is \verb{\{.date x\}}. Default is \code{function(x) format(x, format = "\%F")}.}
 
-\item{.time}{The function to apply to \code{x} when the template is \verb{\{..time x\}}. Default is \code{function(x) format(x, format = "\%T")}.}
+\item{.time}{The function to apply to \code{x} when the template is \verb{\{.time x\}}. Default is \code{function(x) format(x, format = "\%T")}.}
 
-\item{.datetime}{The function to apply to \code{x} when the template is \verb{\{..datetime x\}}. Default is \code{function(x) format(x, format = "\%F \%T")}.}
+\item{.datetime}{The function to apply to \code{x} when the template is \verb{\{.datetime x\}} or \verb{\{.dttm x\}}. Default is \code{function(x) format(x, format = "\%F \%T")}.}
 
-\item{.dollar}{The function to apply to \code{x} when the template is \verb{\{..dollar x\}}. Default is scales::label_dollar().}
+\item{.dollar}{The function to apply to \code{x} when the template is \verb{\{.dollar x\}}. Default is scales::label_dollar().}
 
-\item{.number}{The function to apply to \code{x} when the template is \verb{\{..number x\}}. Default is scales::label_number().}
+\item{.number}{The function to apply to \code{x} when the template is \verb{\{.number x\}} or \verb{\{.num x\}}. Default is scales::label_number().}
 
-\item{.comma}{The function to apply to \code{x} when the template is \verb{\{..comma x\}}. Default is scales::label_comma().}
+\item{.comma}{The function to apply to \code{x} when the template is \verb{\{.comma x\}}. Default is scales::label_comma().}
 
-\item{.ordinal}{The function to apply to \code{x} when the template is \verb{\{..ordinal x\}}. Default is scales::label_ordinal().}
+\item{.ordinal}{The function to apply to \code{x} when the template is \verb{\{.ordinal x\}}. Default is scales::label_ordinal().}
 
-\item{.percent}{The function to apply to \code{x} when the template is \verb{\{..percent x\}}. Default is scales::label_percent().}
+\item{.percent}{The function to apply to \code{x} when the template is \verb{\{.percent x\}} or \verb{\{.pct x\}}. Default is scales::label_percent().}
 
-\item{.pvalue}{The function to apply to \code{x} when the template is \verb{\{..pvalue x\}}. Default is scales::label_pvalue().}
+\item{.pvalue}{The function to apply to \code{x} when the template is \verb{\{.pvalue x\}}. Default is scales::label_pvalue().}
 
-\item{.scientific}{The function to apply to \code{x} when the template is \verb{\{..scientific x\}}. Default is scales::label_scientific().}
+\item{.scientific}{The function to apply to \code{x} when the template is \verb{\{.scientific x\}}. Default is scales::label_scientific().}
 
-\item{.uppercase}{The function to apply to \code{x} when the template is \verb{\{..uppercase x\}}. Default is \code{\link[=toupper]{toupper()}}.}
+\item{.uppercase}{The function to apply to \code{x} when the template is \verb{\{.uppercase x\}} or \verb{\{.uc x\}}. Default is \code{\link[=toupper]{toupper()}}.}
 
-\item{.lowercase}{The function to apply to \code{x} when the template is \verb{\{..lowercase x\}}. Default is \code{\link[=tolower]{tolower()}}.}
+\item{.lowercase}{The function to apply to \code{x} when the template is \verb{\{.lowercase x\}} or \verb{\{.lc x\}}. Default is \code{\link[=tolower]{tolower()}}.}
 
-\item{.titlecase}{The function to apply to \code{x} when the template is \verb{\{..titlecase x\}}. Default is \code{\link[tools:toTitleCase]{tools::toTitleCase()}}.}
+\item{.titlecase}{The function to apply to \code{x} when the template is \verb{\{.titlecase x\}} or \verb{\{.tc x\}}. Default is \code{\link[tools:toTitleCase]{tools::toTitleCase()}}.}
 
-\item{.sentence}{The function to apply to \code{x} when the template is \verb{\{..sentence x\}}. Default is \verb{function(x) }substr<-\verb{(x, 1, 1, toupper(substr(x, 1, 1)))}.}
+\item{.sentence}{The function to apply to \code{x} when the template is \verb{\{.sentence x\}} or \verb{\{.sc x\}}. Default is \verb{function(x) }substr<-\verb{(x, 1, 1, toupper(substr(x, 1, 1)))}.}
 
-\item{.squote}{The function to apply to \code{x} when the template is \verb{\{..squote x\}}. Default is \code{function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
+\item{.squote}{The function to apply to \code{x} when the template is \verb{\{.squote x\}}. Default is \code{function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
 
-\item{.dquote}{The function to apply to \code{x} when the template is \verb{\{..dquote x\}}. Default is \code{function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
+\item{.dquote}{The function to apply to \code{x} when the template is \verb{\{.dquote x\}}. Default is \code{function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
 
-\item{.strong}{The function to apply to \code{x} when the template is \verb{\{..strong x\}}. Default is chosen internally based on the output format.}
+\item{.strong}{The function to apply to \code{x} when the template is \verb{\{.strong x\}} or \verb{\{.bold x\}}. Default is chosen internally based on the output format.}
 
-\item{.emph}{The function to apply to \code{x} when the template is \verb{\{..emph x\}}. Default is chosen internally based on the output format.}
+\item{.emph}{The function to apply to \code{x} when the template is \verb{\{.emph x\}} or \verb{\{.italic x\}}. Default is chosen internally based on the output format.}
 
-\item{.code}{The function to apply to \code{x} when the template is \verb{\{..code x\}}. Default is chosen internally based on the output format.}
+\item{.code}{The function to apply to \code{x} when the template is \verb{\{.code x\}}. Default is chosen internally based on the output format.}
 }
 \value{
 A function of \code{text} and \code{envir} suitable for the \code{.transformer} argument of

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -54,7 +54,7 @@ the current transformation. In nearly all cases, you can let
 
 \item{.decr}{The function to apply to \code{x} when the template is \verb{\{.decr x\}}. Default is \code{function(x) sort(x, decreasing = TRUE)}.}
 
-\item{.bytes}{The function to apply to \code{x} when the template is \verb{\{.bytes x\}}. Default is scales::label_bytes().}
+\item{.bytes}{The function to apply to \code{x} when the template is \verb{\{.bytes x\}}. Default is \link[scales:label_bytes]{scales::label_bytes()}.}
 
 \item{.date}{The function to apply to \code{x} when the template is \verb{\{.date x\}}. Default is \code{function(x) format(x, format = "\%F")}.}
 
@@ -62,19 +62,19 @@ the current transformation. In nearly all cases, you can let
 
 \item{.datetime}{The function to apply to \code{x} when the template is \verb{\{.datetime x\}} or \verb{\{.dttm x\}}. Default is \code{function(x) format(x, format = "\%F \%T")}.}
 
-\item{.dollar}{The function to apply to \code{x} when the template is \verb{\{.dollar x\}}. Default is scales::label_dollar().}
+\item{.dollar}{The function to apply to \code{x} when the template is \verb{\{.dollar x\}}. Default is \link[scales:label_dollar]{scales::label_dollar(prefix = engine_pick("$", "$", "\\$"))}.}
 
-\item{.number}{The function to apply to \code{x} when the template is \verb{\{.number x\}} or \verb{\{.num x\}}. Default is scales::label_number().}
+\item{.number}{The function to apply to \code{x} when the template is \verb{\{.number x\}} or \verb{\{.num x\}}. Default is \link[scales:label_number]{scales::label_number()}.}
 
-\item{.comma}{The function to apply to \code{x} when the template is \verb{\{.comma x\}}. Default is scales::label_comma().}
+\item{.comma}{The function to apply to \code{x} when the template is \verb{\{.comma x\}}. Default is \link[scales:label_number]{scales::label_comma()}.}
 
-\item{.ordinal}{The function to apply to \code{x} when the template is \verb{\{.ordinal x\}}. Default is scales::label_ordinal().}
+\item{.ordinal}{The function to apply to \code{x} when the template is \verb{\{.ordinal x\}}. Default is \link[scales:label_ordinal]{scales::label_ordinal()}.}
 
-\item{.percent}{The function to apply to \code{x} when the template is \verb{\{.percent x\}} or \verb{\{.pct x\}}. Default is scales::label_percent().}
+\item{.percent}{The function to apply to \code{x} when the template is \verb{\{.percent x\}} or \verb{\{.pct x\}}. Default is \link[scales:label_percent]{scales::label_percent(suffix = engine_pick("\%", "\%", "\\\%"))}.}
 
-\item{.pvalue}{The function to apply to \code{x} when the template is \verb{\{.pvalue x\}}. Default is scales::label_pvalue().}
+\item{.pvalue}{The function to apply to \code{x} when the template is \verb{\{.pvalue x\}}. Default is \link[scales:label_pvalue]{scales::label_pvalue()}.}
 
-\item{.scientific}{The function to apply to \code{x} when the template is \verb{\{.scientific x\}}. Default is scales::label_scientific().}
+\item{.scientific}{The function to apply to \code{x} when the template is \verb{\{.scientific x\}}. Default is \link[scales:label_scientific]{scales::label_scientific()}.}
 
 \item{.uppercase}{The function to apply to \code{x} when the template is \verb{\{.uppercase x\}} or \verb{\{.uc x\}}. Default is \code{\link[=toupper]{toupper()}}.}
 
@@ -82,7 +82,7 @@ the current transformation. In nearly all cases, you can let
 
 \item{.titlecase}{The function to apply to \code{x} when the template is \verb{\{.titlecase x\}} or \verb{\{.tc x\}}. Default is \code{function(x) tools::toTitleCase(as.character(x))}.}
 
-\item{.sentence}{The function to apply to \code{x} when the template is \verb{\{.sentence x\}} or \verb{\{.sc x\}}. Default is \verb{function(x) }substr<-\verb{(x, 1, 1, toupper(substr(x, 1, 1)))}.}
+\item{.sentence}{The function to apply to \code{x} when the template is \verb{\{.sentence x\}} or \verb{\{.sc x\}}. Default is \code{function(x) `substr<-`(x, 1, 1, toupper(substr(x, 1, 1)))}.}
 
 \item{.squote}{The function to apply to \code{x} when the template is \verb{\{.squote x\}}. Default is \code{function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE))}.}
 

--- a/man/epoxy_transform_inline.Rd
+++ b/man/epoxy_transform_inline.Rd
@@ -24,7 +24,7 @@ epoxy_transform_inline(
   .scientific = scales::label_scientific(),
   .uppercase = toupper,
   .lowercase = tolower,
-  .titlecase = tools::toTitleCase,
+  .titlecase = function(x) tools::toTitleCase(as.character(x)),
   .sentence = function(x) `substr<-`(x, 1, 1, toupper(substr(x, 1, 1))),
   .squote = function(x) sQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
   .dquote = function(x) dQuote(x, q = getOption("epoxy.fancy_quotes", FALSE)),
@@ -80,7 +80,7 @@ the current transformation. In nearly all cases, you can let
 
 \item{.lowercase}{The function to apply to \code{x} when the template is \verb{\{.lowercase x\}} or \verb{\{.lc x\}}. Default is \code{\link[=tolower]{tolower()}}.}
 
-\item{.titlecase}{The function to apply to \code{x} when the template is \verb{\{.titlecase x\}} or \verb{\{.tc x\}}. Default is \code{\link[tools:toTitleCase]{tools::toTitleCase()}}.}
+\item{.titlecase}{The function to apply to \code{x} when the template is \verb{\{.titlecase x\}} or \verb{\{.tc x\}}. Default is \code{function(x) tools::toTitleCase(as.character(x))}.}
 
 \item{.sentence}{The function to apply to \code{x} when the template is \verb{\{.sentence x\}} or \verb{\{.sc x\}}. Default is \verb{function(x) }substr<-\verb{(x, 1, 1, toupper(substr(x, 1, 1)))}.}
 

--- a/tests/testthat/test-epoxy_transform_inline.R
+++ b/tests/testthat/test-epoxy_transform_inline.R
@@ -82,6 +82,19 @@ describe("epoxy_transform_inline()", {
 		)
 	})
 
+	it("applies .sentence and .sc", {
+		start <- "it was a dark and stormy night"
+		expect_equal(
+			epoxy("{.sentence start}", .transformer = "inline"),
+			"It was a dark and stormy night"
+		)
+
+		expect_equal(
+			epoxy("{.sc start}", .transformer = "inline"),
+			"It was a dark and stormy night"
+		)
+	})
+
 	it("errors if a non-dotted argument name is provided", {
 		expect_snapshot_error(
 			epoxy_transform_inline(


### PR DESCRIPTION
Adds a `.sentence` inline transformer that capitalizes the first character of the word.

``` r
things <- c("this or that", "the others", "that third thing")

epoxy("{.sentence things}")
#> This or that
#> The others
#> That third thing

epoxy("{.sc things}")
#> This or that
#> The others
#> That third thing
```

The primary use case is when you're using a variable to start a sentence, where `.titlecase` might capitalize more than just the first word.