### PR TITLE
feat(.collapse): Add collapse argument to `epoxy` and all downstream functions

### DIFF
--- a/R/engines.R
+++ b/R/engines.R
@@ -128,6 +128,7 @@ eval_epoxy_engine <- function(fn, code, options) {
 	defaults <- defaults[setdiff(names(defaults), exclude)]
 	defaults <- lapply(defaults, rlang::eval_bare, env = environment(fn))
 	defaults$.envir <- knitr::knit_global()
+	defaults$.collapse  <- "\n"
 
 	chunk_opt_names <- c("data", ".data", names(defaults))
 	chunk_opts <- options[intersect(chunk_opt_names, names(options))]
@@ -137,8 +138,7 @@ eval_epoxy_engine <- function(fn, code, options) {
 	args <- purrr::list_assign(defaults, !!!chunk_opts)
 	args$.transformer <- epoxy_options_get_transformer(options)
 
-	out <- rlang::exec(fn, code, !!!args)
-	glue_collapse(out, sep = "\n")
+	rlang::exec(fn, code, !!!args)
 }
 
 knitr_engine_epoxy <- function(options) {

--- a/R/epoxy.R
+++ b/R/epoxy.R
@@ -44,6 +44,8 @@
 #'   around the template variable or expression. Doubling the full delimiter
 #'   escapes it.
 ####
+#' @param .collapse A character string used to collapse a vector result into a
+#'   single value. If `NULL` (the default), the result is not collapsed.
 #' @inheritParams glue::glue
 #'
 #' @return Returns a transformed string, using `glue::glue()` but with the
@@ -72,6 +74,7 @@ epoxy <- function(
 	.literal = FALSE,
 	.trim = FALSE,
 	.transformer = NULL,
+	.collapse = NULL,
 	.style = lifecycle::deprecated()
 ) {
 	if (lifecycle::is_present(.style)) {
@@ -100,7 +103,7 @@ epoxy <- function(
 	old_opts <- options("epoxy:::private" = list(.open = .open, .close = .close))
 	on.exit(old_opts, add = TRUE)
 
-	glue_data(
+	res <- glue_data(
 		.x = .data,
 		...,
 		.sep     = .sep,
@@ -114,6 +117,12 @@ epoxy <- function(
 		.trim    = .trim,
 		.transformer = epoxy_options_get_transformer(opts_transformer)
 	)
+
+	if (is.null(.collapse) || length(res) <= 1) {
+		return(res)
+	}
+
+	glue_collapse(res, sep = .collapse)
 }
 
 
@@ -131,7 +140,8 @@ epoxy_html <- function(
 	.comment = "",
 	.literal = FALSE,
 	.trim = FALSE,
-	.transformer = NULL
+	.transformer = NULL,
+	.collapse = NULL
 ) {
 	res <-
 		with_epoxy_engine(
@@ -148,7 +158,8 @@ epoxy_html <- function(
 				.comment = .comment,
 				.literal = .literal,
 				.trim = .trim,
-				.transformer = .transformer
+				.transformer = .transformer,
+				.collapse = .collapse
 			)
 		)
 	html_chr(res)
@@ -169,7 +180,8 @@ epoxy_latex <- function(
 	.comment = "",
 	.literal = FALSE,
 	.trim = FALSE,
-	.transformer = NULL
+	.transformer = NULL,
+	.collapse = NULL
 ) {
 	with_epoxy_engine(
 		"latex",
@@ -185,7 +197,8 @@ epoxy_latex <- function(
 			.comment = .comment,
 			.literal = .literal,
 			.trim = .trim,
-			.transformer = .transformer
+			.transformer = .transformer,
+			.collapse = .collapse
 		)
 	)
 }

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -23,7 +23,7 @@ render_rmd <- function(
 render_basic_rmd <- function(..., envir = parent.frame()) {
 	render_rmd(c(
 		"---",
-		"output: markdown_document",
+		"output: md_document",
 		"---",
 		"",
 		...

--- a/tests/testthat/rmds/use-chunk_collapse.Rmd
+++ b/tests/testthat/rmds/use-chunk_collapse.Rmd
@@ -1,0 +1,24 @@
+---
+output: md_document
+---
+
+```{r setup, include=FALSE}
+library(epoxy)
+
+the_data <- list(
+	first = c("one", "three"),
+	second = c("two", "four")
+)
+```
+
+```{epoxy chunk-template, .data = the_data, .collapse = " == "}
+{first} followed by {second}
+```
+
+```{r echo=FALSE}
+epoxy_use_chunk(
+	.data = the_data,
+	label = "chunk-template",
+	.collapse = " || "
+)
+```

--- a/tests/testthat/test-engines.R
+++ b/tests/testthat/test-engines.R
@@ -233,3 +233,19 @@ describe("chunk engine deprecations", {
 		)
 	})
 })
+
+test_that(".collapse chunk option", {
+	rmd <- test_path("rmds", "use-chunk_collapse.Rmd")
+
+  res <- render_rmd(rmd)
+
+	expect_equal(
+		res[[1]],
+		"one followed by two == three followed by four"
+	)
+
+	expect_equal(
+		res[[3]],
+		"one followed by two || three followed by four"
+	)
+})

--- a/tests/testthat/test-epoxy.R
+++ b/tests/testthat/test-epoxy.R
@@ -18,6 +18,37 @@ test_that("epoxy .data pronoun", {
 	)
 })
 
+test_that("epoxy(.collapse =)", {
+	expect_equal(
+		epoxy("{letters[1:3]}", .collapse = ", "),
+		"a, b, c"
+	)
+
+	expect_equal(
+		epoxy_latex("<<letters[1:3]>>", .collapse = " \\middot "),
+		"a \\middot b \\middot c"
+	)
+
+	expect_equal(
+		epoxy_html(
+			"{{values}}",
+			values = letters[1:3],
+			.collapse = "<br>"
+		),
+		"a<br>b<br>c"
+	)
+
+	expect_equal(
+		epoxy_html(
+			"{{li values}}",
+			values = letters[1:3],
+			# inline html tranformers pre-collapse
+			.collapse = "<br>"
+		),
+		"<li>a</li><li>b</li><li>c</li>"
+	)
+})
+
 test_that("epoxy_data_subset()", {
 	nested <- list(
 		outer = list(


### PR DESCRIPTION
Closes #114

``` r
pkgload::load_all("~/play/gadenbuie/epoxy")
#> ℹ Loading epoxy

epoxy("{letters[1:3]}")
#> a
#> b
#> c
epoxy("{letters[1:3]}", .collapse = " | ")
#> a | b | c

epoxy_latex("<< letters[1:3] >>", .collapse = " \\middot ")
#> a \middot b \middot c

epoxy_html("{{ letters[1:3] }}", .collapse = "<br>")
#> a<br>b<br>c
```

But note that the html inline transformer already collapses vector expressions.

``` r
epoxy_html("{{ li letters[1:3] }}", .collapse = "<br>")
#> <li>a</li><li>b</li><li>c</li>
```
